### PR TITLE
column bug fix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6343,6 +6343,9 @@ function loadProjectsData(token, config, snapshot) {
                 let colNames = config.columnMap[key];
                 for (const colName of colNames) {
                     let colId = projMap[projectUrl].columns[colName];
+                    if (!colId) {
+                        continue;
+                    }
                     let cards = yield github.getCardsForColumns(colId, colName);
                     for (const card of cards) {
                         // cached since real column could be mapped to two different mapped columns

--- a/generator.ts
+++ b/generator.ts
@@ -251,6 +251,11 @@ async function loadProjectsData(token: string, config: GeneratorConfiguration, s
             for (const colName of colNames) {
                 let colId = projMap[projectUrl].columns[colName];
 
+                // it's possible the column name is a previous column name
+                if (!colId) {
+                    continue;
+                }
+
                 let cards = await github.getCardsForColumns(colId, colName);
 
                 for (const card of cards) {

--- a/samples/sample.yaml
+++ b/samples/sample.yaml
@@ -1,10 +1,12 @@
 name: "TODO"
 columnMap:
-  Proposed: ["In Box"]                  # Drafts author is working on.  Has a chance of moving soon
-  Accepted: ["Next"]                    # Ready for review
-  In-Progress: ["In Progress"]          # Work is underway
-  Done: ["Complete"]                    # Celebrate
-  Blocked: []                           # Blocked, e.g. waiting on external etc.
+  Proposed: ["In Box"]           # Drafts author is working on.  Has a chance of moving soon
+  Accepted: [
+    "Up Next",                   # Ready for review
+    "Next"]                      # Previous name of column       
+  In-Progress: ["In Progress"]   # Work is underway
+  Done: ["Complete"]             # Celebrate
+  Blocked: []                    # Blocked, e.g. waiting on external etc.
 
 projects: 
   - https://github.com/users/bryanmacfarlane/projects/1


### PR DESCRIPTION
If a column is a previous column name for mappings to work, it will get a 404 trying to get cards for a non existent column.  simple check.