### PR TITLE
warn on unmapped mentioned columns

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,6 +1,6 @@
 import * as util from '../util'
 
-import {IssueCard, GeneratorConfiguration} from '../interfaces';
+import {IssueCard, IssueCardEvent, GeneratorConfiguration} from '../interfaces';
 
 let doneCard = require('./util.test.done.json') as IssueCard;
 
@@ -70,7 +70,7 @@ describe('util', () => {
         "Blocked": []
       };    
 
-    util.processCard(doneCard, 4969651, config);
+    util.processCard(doneCard, 4969651, config, (event: IssueCardEvent):void => {});
     expect(doneCard).toBeDefined();
     expect(doneCard.events[0].project_card.stage_name).toBe("Proposed");
     expect(doneCard.project_stage).toBe("Done");

--- a/util.ts
+++ b/util.ts
@@ -1,4 +1,4 @@
-import {GeneratorConfiguration, IssueCard, ProjectData} from './interfaces'
+import {GeneratorConfiguration, IssueCard, IssueCardEvent} from './interfaces'
 
 export function getTimeForOffset(date: Date, offset: number) {
     var utc = date.getTime() + (date.getTimezoneOffset() * 60000);
@@ -68,7 +68,7 @@ let stageAtNames = [
 // process a card in context of the project it's being added to
 // filter column events to the project being processed only since. this makes it easier on the report author
 // add stage name to column move events so report authors don't have to repeatedly to that
-export function processCard(card: IssueCard, projectId: number, config: GeneratorConfiguration) {
+export function processCard(card: IssueCard, projectId: number, config: GeneratorConfiguration, eventCallback: (event: IssueCardEvent) => void) {
     let filteredEvents = [];
 
     // card events should be in order chronologically
@@ -85,6 +85,8 @@ export function processCard(card: IssueCard, projectId: number, config: Generato
             if (event.project_card && event.project_card.project_id !== projectId) {
                 continue;
             }
+
+            eventCallback(event);
             
             let eventDateTime: Date;
             if (event.created_at) {


### PR DESCRIPTION
warn if there are columns mentioned on existing board cards that are not in the column mappings.  
this is very likely a problem since we only visit the mapped stages.

<img width="690" alt="Screen Shot 2020-07-28 at 9 54 20 AM" src="https://user-images.githubusercontent.com/919564/88675644-21093480-d0b9-11ea-827c-d6a7377b367a.png">
