### PR TITLE
start limits report

### DIFF
--- a/samples/sample.yaml
+++ b/samples/sample.yaml
@@ -19,6 +19,18 @@ reports:
     kind: markdown 
     timezoneOffset: -8
     sections:
+      - name: "limits"
+        config: 
+          report-on-label: '*'
+          accepted-limit: 2
+          in-progress-limit: 2
+          count-label-match: "(\\d+)-dev"
+      - name: "limits"
+        config: 
+          report-on-label: 'Epic'
+          accepted-limit: 2
+          in-progress-limit: 2
+          count-label-match: "(\\d+)-dev"
       - name: "wip-limits"
         config: 
           report-on: ["*", "Epic"]


### PR DESCRIPTION
create a limits report that works on one type.  you can add multiple to the reports section for multiple independent configs

<img width="482" alt="Screen Shot 2020-07-29 at 8 30 59 PM" src="https://user-images.githubusercontent.com/919564/88867176-b05a3900-d1da-11ea-8a68-17bf4058a732.png">
