### PR TITLE
Fuzzy match on column mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ _reports
 dist/samples
 tag.sh
 
-samples/debug.yml
+samples/debug*.yml

--- a/__tests__/in-progress.test.ts
+++ b/__tests__/in-progress.test.ts
@@ -56,13 +56,13 @@ describe('project-in-progress', () => {
         expect(cards[0]).toBeDefined();
         expect(cards[0].title).toBe("gRPC generation");
         expect(cards[0].flagHoursLastUpdated).toBeTruthy();
-        expect(cards[0].inProgressSince).toContain('days ago');
+        expect(cards[0].inProgressSince).toContain('ago');
         expect(cards[0].hoursInProgress).toBeGreaterThan(120);
 
         expect(cards[1]).toBeDefined();
         expect(cards[1].title).toBe("Initial Web UI");
         expect(cards[0].flagHoursLastUpdated).toBeTruthy();
-        expect(cards[0].inProgressSince).toContain('days ago');
+        expect(cards[0].inProgressSince).toContain('ago');
         expect(cards[1].hoursInProgress).toBeGreaterThan(160);
     });
     

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -40,6 +40,23 @@ describe('report-lib', () => {
 
   afterAll(async () => {}, 100000);
 
+  it('fuzzy matches column names', async () => {
+
+    // fuzzy match
+    //                        are in this <== all these "words"
+    expect(rptLib.fuzzyMatch("In progress", "In progress")).toBeTruthy();
+    expect(rptLib.fuzzyMatch("In progress", " IN Progress.")).toBeTruthy();
+    expect(rptLib.fuzzyMatch("In-Progress: A Category", "in Progress")).toBeTruthy();
+    expect(rptLib.fuzzyMatch(" In-Progress 👩🏼‍💻👨🏽‍💻 ", "in progress!")).toBeTruthy();
+    expect(rptLib.fuzzyMatch("\tIn-Progress 👩🏼‍💻 ", " in...progress👨🏽‍💻")).toBeTruthy();
+
+    // should not fuzzy match
+    //                     are not in this <== all these "words"
+    expect(rptLib.fuzzyMatch("Into progress", "In progress")).toBeFalsy;
+    expect(rptLib.fuzzyMatch("In progress", "Into progress")).toBeFalsy;
+    expect(rptLib.fuzzyMatch("pre progress", "In progress")).toBeFalsy;
+  });  
+
   it('finds cards by label', async () => {
     let filtered = rptLib.filterByLabel(testCards, 'two')
     expect(filtered).toBeDefined();

--- a/crawler.ts
+++ b/crawler.ts
@@ -92,7 +92,6 @@ class ProjectCrawler {
         console.log(`Crawling project ${target.htmlUrl} ...`);
 
         let issues: ProjectIssue[] = [];
-        // let columns: { [key: string]: number } = {};
 
         let projectData = await this.github.getProject(target.htmlUrl);
         if (!projectData) {
@@ -100,9 +99,6 @@ class ProjectCrawler {
         }
 
         let columns: ProjectColumn[] = await this.github.getColumnsForProject(projectData);
-        // cols.forEach((col) => {
-        //     columns[col.name] = col.id;
-        // })
 
         let mappedColumns = [];
         for (const stageName in target.columnMap) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6204,13 +6204,15 @@ function generate(token, configYaml) {
                 let defaultStages = ['Proposed', 'Accepted', 'In-Progress', 'Done', 'Unmapped'];
                 for (let phase of defaultStages) {
                     if (!target.columnMap[phase]) {
-                        target.columnMap[phase] = [phase];
+                        target.columnMap[phase] = [];
                     }
                 }
-                // make sure "In Progress" (default in GH Kanban) is synonymous with In-Progress
-                if (target.columnMap['In-Progress'].indexOf('In progress') === -1) {
-                    target.columnMap['In-Progress'].push('In progress');
-                }
+                target.columnMap['Proposed'].push('Proposed', 'Not Started');
+                target.columnMap['In-Progress'].push('In-Progress', 'In progress', 'InProgress', 'Started');
+                target.columnMap['Accepted'].push('Accepted', 'Approved', 'Up Next');
+                target.columnMap['Done'].push('Done', 'Completed', 'Complete');
+                // Add some common mappings
+                target.columnMap['Proposed'].push('Triage', 'Not Started');
                 for (let mapName in target.columnMap) {
                     target.columnMap[mapName] = target.columnMap[mapName].map(item => item.trim());
                 }
@@ -20090,16 +20092,9 @@ class ProjectCrawler {
                 mappedColumns = mappedColumns.concat(colNames);
             }
             let seenUnmappedColumns = [];
-            // for (const key in target.columnMap) {
-            //     console.log(`Processing stage ${key}`);
-            //     let colNames = target.columnMap[key];
             for (const column of columns) {
-                console.log(`Processing column ${column.name} (${column.id})`);
-                // let colId = columns[colName];
-                // it's possible the column name is a previous column name
-                // if (!colId) {
-                //     continue;
-                // }
+                console.log();
+                console.log(`>> Processing column ${column.name} (${column.id})`);
                 let cards = yield this.github.getCardsForColumns(column.id);
                 for (const card of cards) {
                     // called as each event is processed 
@@ -20139,7 +20134,6 @@ class ProjectCrawler {
                     }
                 }
             }
-            //}
             console.log("Done processing.");
             console.log();
             if (seenUnmappedColumns.length > 0) {
@@ -20160,6 +20154,9 @@ class ProjectCrawler {
         if (!projectId) {
             throw new Error('projectId not set');
         }
+        console.log();
+        console.log(`Processing card ${card.title}`);
+        console.log(card.html_url);
         let filteredEvents = [];
         // card events should be in order chronologically
         let currentStage;
@@ -20180,6 +20177,7 @@ class ProjectCrawler {
                         console.log(`WARNING: could not map for column ${event.project_card.column_name}`);
                     }
                     event.project_card.stage_name = stage || "Unmapped";
+                    console.log(`${event.created_at}: ${event.project_card.column_name} => ${event.project_card.stage_name}`);
                 }
                 if (event.project_card && event.project_card.previous_column_name) {
                     let previousStage = this.getStageFromColumn(event.project_card.previous_column_name, target);
@@ -20187,6 +20185,7 @@ class ProjectCrawler {
                         console.log(`WARNING: could not map for previous column ${event.project_card.previous_column_name}`);
                     }
                     event.project_card.previous_stage_name = previousStage || "Unmapped";
+                    console.log(`${event.created_at}: ${event.project_card.previous_column_name} => ${event.project_card.previous_stage_name}`);
                 }
                 filteredEvents.push(event);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -6211,6 +6211,9 @@ function generate(token, configYaml) {
                 if (target.columnMap['In-Progress'].indexOf('In progress') === -1) {
                     target.columnMap['In-Progress'].push('In progress');
                 }
+                for (let mapName in target.columnMap) {
+                    target.columnMap[mapName] = target.columnMap[mapName].map(item => item.trim());
+                }
             }
         }
         console.log('crawlConfig');
@@ -6576,7 +6579,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(482);
@@ -6638,6 +6641,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",
@@ -20042,7 +20060,7 @@ class ProjectCrawler {
     constructor(client) {
         // cache the resolution of stage names for a column
         // a columns by stage names are the default and resolve immediately
-        this.columnMap = {
+        this.resolvedColumns = {
             "proposed": "Proposed",
             "accepted": "Accepted",
             "in-progress": "In-Progress",
@@ -20054,73 +20072,74 @@ class ProjectCrawler {
         return __awaiter(this, void 0, void 0, function* () {
             console.log(`Crawling project ${target.htmlUrl} ...`);
             let issues = [];
-            let columns = {};
+            // let columns: { [key: string]: number } = {};
             let projectData = yield this.github.getProject(target.htmlUrl);
             if (!projectData) {
                 throw new Error(`Could not find project ${target.htmlUrl}`);
             }
-            let cols = yield this.github.getColumnsForProject(projectData);
-            cols.forEach((col) => {
-                columns[col.name] = col.id;
-            });
+            let columns = yield this.github.getColumnsForProject(projectData);
+            // cols.forEach((col) => {
+            //     columns[col.name] = col.id;
+            // })
             let mappedColumns = [];
-            for (const key in target.columnMap) {
-                let colNames = target.columnMap[key];
+            for (const stageName in target.columnMap) {
+                let colNames = target.columnMap[stageName];
                 if (!colNames || !Array.isArray) {
-                    throw new Error(`Invalid config. column map for ${key} is not an array`);
+                    throw new Error(`Invalid config. column map for ${stageName} is not an array`);
                 }
                 mappedColumns = mappedColumns.concat(colNames);
             }
             let seenUnmappedColumns = [];
-            for (const key in target.columnMap) {
-                console.log(`Processing stage ${key}`);
-                let colNames = target.columnMap[key];
-                for (const colName of colNames) {
-                    let colId = columns[colName];
-                    // it's possible the column name is a previous column name
-                    if (!colId) {
-                        continue;
-                    }
-                    let cards = yield this.github.getCardsForColumns(colId, colName);
-                    for (const card of cards) {
-                        // called as each event is processed 
-                        // creating a list of mentioned columns existing cards in the board in events that aren't mapped in the config
-                        // this will help diagnose a potential config issue much faster
-                        let eventCallback = (event) => {
-                            let mentioned = [];
-                            if (event.project_card && event.project_card.column_name) {
-                                mentioned.push(event.project_card.column_name);
-                            }
-                            if (event.project_card && event.project_card.previous_column_name) {
-                                mentioned.push(event.project_card.previous_column_name);
-                            }
-                            for (let mention of mentioned) {
-                                if (mappedColumns.indexOf(mention) === -1 && seenUnmappedColumns.indexOf(mention) === -1) {
-                                    seenUnmappedColumns.push(mention);
-                                }
-                            }
-                        };
-                        // cached since real column could be mapped to two different mapped columns
-                        // read and build the event list once
-                        let issueCard = yield this.github.getIssueForCard(card, projectData.id);
-                        if (issueCard) {
-                            this.processCard(issueCard, projectData.id, target, eventCallback);
-                            issues.push(issueCard);
+            // for (const key in target.columnMap) {
+            //     console.log(`Processing stage ${key}`);
+            //     let colNames = target.columnMap[key];
+            for (const column of columns) {
+                console.log(`Processing column ${column.name} (${column.id})`);
+                // let colId = columns[colName];
+                // it's possible the column name is a previous column name
+                // if (!colId) {
+                //     continue;
+                // }
+                let cards = yield this.github.getCardsForColumns(column.id);
+                for (const card of cards) {
+                    // called as each event is processed 
+                    // creating a list of mentioned columns existing cards in the board in events that aren't mapped in the config
+                    // this will help diagnose a potential config issue much faster
+                    let eventCallback = (event) => {
+                        let mentioned = [];
+                        if (event.project_card && event.project_card.column_name) {
+                            mentioned.push(event.project_card.column_name);
                         }
-                        else {
-                            let contents = card["note"];
-                            try {
-                                new url_1.URL(contents);
-                                console.log(contents);
-                                console.log("WWARNING: card found that is not an issue but has contents of an issues url that is not part of the project");
+                        if (event.project_card && event.project_card.previous_column_name) {
+                            mentioned.push(event.project_card.previous_column_name);
+                        }
+                        for (let mention of mentioned) {
+                            if (mappedColumns.indexOf(mention.trim()) === -1 && seenUnmappedColumns.indexOf(mention) === -1) {
+                                seenUnmappedColumns.push(mention);
                             }
-                            catch (_a) {
-                                console.log(`ignoring note: ${contents}`);
-                            }
+                        }
+                    };
+                    // cached since real column could be mapped to two different mapped columns
+                    // read and build the event list once
+                    let issueCard = yield this.github.getIssueForCard(card, projectData.id);
+                    if (issueCard) {
+                        this.processCard(issueCard, projectData.id, target, eventCallback);
+                        issues.push(issueCard);
+                    }
+                    else {
+                        let contents = card["note"];
+                        try {
+                            new url_1.URL(contents);
+                            console.log(contents);
+                            console.log("WWARNING: card found that is not an issue but has contents of an issues url that is not part of the project");
+                        }
+                        catch (_a) {
+                            console.log(`ignoring note: ${contents}`);
                         }
                     }
                 }
             }
+            //}
             console.log("Done processing.");
             console.log();
             if (seenUnmappedColumns.length > 0) {
@@ -20175,16 +20194,14 @@ class ProjectCrawler {
         }
     }
     getStageFromColumn(column, target) {
-        column = column.toLowerCase();
-        if (this.columnMap[column]) {
-            return this.columnMap[column];
+        if (this.resolvedColumns[column]) {
+            return this.resolvedColumns[column];
         }
         let resolvedStage = null;
         for (let stageName in target.columnMap) {
             // case insensitve match
             for (let mappedColumn of target.columnMap[stageName].filter(e => e)) {
-                let lowerColumn = mappedColumn.toLowerCase();
-                if (lowerColumn.trim() === column.trim().toLowerCase()) {
+                if (project_reports_lib_1.fuzzyMatch(column, mappedColumn)) {
                     resolvedStage = stageName;
                     break;
                 }
@@ -20195,7 +20212,7 @@ class ProjectCrawler {
         }
         // cache the n^2 reverse case insensitive lookup.  it will never change for this run
         if (resolvedStage) {
-            this.columnMap[column] = resolvedStage;
+            this.resolvedColumns[column] = resolvedStage;
         }
         return resolvedStage;
     }
@@ -22365,7 +22382,7 @@ class GitHubClient {
             return cols.data;
         });
     }
-    getCardsForColumns(colId, colName) {
+    getCardsForColumns(colId) {
         return __awaiter(this, void 0, void 0, function* () {
             let cards = yield this.octokit.projects.listCards({ column_id: colId });
             return cards.data;

--- a/dist/reports/project-cycle-time/index.js
+++ b/dist/reports/project-cycle-time/index.js
@@ -584,7 +584,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -646,6 +646,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/dist/reports/project-cycle-time/index.js
+++ b/dist/reports/project-cycle-time/index.js
@@ -474,7 +474,7 @@ function renderMarkdown(projData, processedData) {
         ctRow.labels = `\`${cardType}\``;
         ctRow.count = stageData.count;
         ctRow.cycleTimeInDays = ` ${stageData.cycletime ? stageData.cycletime.toFixed(2) : ""} ${stageData.flag ? ":triangular_flag_on_post:" : ""}`;
-        ctRow.limit = stageData.limit;
+        ctRow.limit = stageData.limit >= 0 ? stageData.limit.toString() : "";
         rows.push(ctRow);
     }
     let table = tablemark(rows);

--- a/dist/reports/project-done/index.js
+++ b/dist/reports/project-done/index.js
@@ -474,7 +474,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -536,6 +536,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/dist/reports/project-in-progress/index.js
+++ b/dist/reports/project-in-progress/index.js
@@ -671,7 +671,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -733,6 +733,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/dist/reports/project-limits/index.js
+++ b/dist/reports/project-limits/index.js
@@ -474,7 +474,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -536,6 +536,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/dist/reports/project-new/index.js
+++ b/dist/reports/project-new/index.js
@@ -577,7 +577,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -639,6 +639,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/dist/reports/repo-issues/index.js
+++ b/dist/reports/repo-issues/index.js
@@ -571,7 +571,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const url = __importStar(__webpack_require__(835));
 const clone = __webpack_require__(97);
 const moment = __webpack_require__(431);
@@ -633,6 +633,21 @@ function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 exports.sumCardProperty = sumCardProperty;
+function fuzzyMatch(content, match) {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+    let isMatch = true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+exports.fuzzyMatch = fuzzyMatch;
 // stages more discoverable
 exports.ProjectStages = {
     Proposed: "Proposed",

--- a/generator.ts
+++ b/generator.ts
@@ -92,6 +92,10 @@ export async function generate(token: string, configYaml: string): Promise<Repor
             if (target.columnMap['In-Progress'].indexOf('In progress') === -1) {
                 target.columnMap['In-Progress'].push('In progress');
             }
+
+            for (let mapName in target.columnMap) {
+                target.columnMap[mapName] = target.columnMap[mapName].map(item => item.trim());
+            }
         }
     }
 

--- a/generator.ts
+++ b/generator.ts
@@ -84,14 +84,17 @@ export async function generate(token: string, configYaml: string): Promise<Repor
             let defaultStages = ['Proposed', 'Accepted', 'In-Progress', 'Done', 'Unmapped'];
             for (let phase of defaultStages) {
                 if (!target.columnMap[phase]) {
-                    target.columnMap[phase] = [ phase ];
+                    target.columnMap[phase] = [];
                 }
             }
 
-            // make sure "In Progress" (default in GH Kanban) is synonymous with In-Progress
-            if (target.columnMap['In-Progress'].indexOf('In progress') === -1) {
-                target.columnMap['In-Progress'].push('In progress');
-            }
+            target.columnMap['Proposed'].push('Proposed', 'Not Started')
+            target.columnMap['In-Progress'].push('In-Progress', 'In progress', 'InProgress', 'Started');
+            target.columnMap['Accepted'].push('Accepted', 'Approved', 'Up Next')
+            target.columnMap['Done'].push('Done', 'Completed', 'Complete');
+
+            // Add some common mappings
+            target.columnMap['Proposed'].push('Triage', 'Not Started')
 
             for (let mapName in target.columnMap) {
                 target.columnMap[mapName] = target.columnMap[mapName].map(item => item.trim());

--- a/github/index.ts
+++ b/github/index.ts
@@ -2,7 +2,7 @@ const { Octokit } = require('@octokit/rest');
 import * as url from 'url' 
 import {ProjectData} from '../interfaces'
 import * as restCache from './octokit-rest-cache';
-import {IssueList, ProjectIssue, IssueEvent, IssueComment} from '../project-reports-lib';
+import {IssueList, ProjectIssue, ProjectColumn, IssueComment} from '../project-reports-lib';
 
 function DateOrNull(date: string): Date {
     return date ? new Date(date) : null;
@@ -102,12 +102,12 @@ export class GitHubClient {
         return proj;
     }
 
-    public async getColumnsForProject(project): Promise<any> { 
+    public async getColumnsForProject(project): Promise<ProjectColumn[]> { 
         let cols = await this.octokit.projects.listColumns({project_id: project.id});
         return cols.data;
     }
     
-    public async getCardsForColumns(colId: number, colName: string) {    
+    public async getCardsForColumns(colId: number) {    
         let cards = await this.octokit.projects.listCards({column_id: colId});
         return cards.data;
     }

--- a/project-reports-lib.ts
+++ b/project-reports-lib.ts
@@ -72,9 +72,32 @@ export function sumCardProperty(cards: ProjectIssue[], prop: string): number {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }
 
+export function fuzzyMatch(content: string, match: string): boolean {
+    let matchWords = match.match(/[a-zA-Z0-9]+/g);
+    matchWords = matchWords.map(item => item.toLowerCase());
+
+    let contentWords = content.match(/[a-zA-Z0-9]+/g);
+    contentWords = contentWords.map(item => item.toLowerCase());
+
+    let isMatch =  true;
+    for (let matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false;
+            break;
+        }
+    }
+    return isMatch;
+}
+
 // Project issues keyed by the stage they are in
 export interface ProjectIssues {
     stages: { [key: string]: ProjectIssue[] }
+}
+
+export interface ProjectColumn {
+    cards_url: string,
+    id: number,
+    name: string,    
 }
 
 // stages more discoverable

--- a/reports/project-cycle-time.ts
+++ b/reports/project-cycle-time.ts
@@ -21,7 +21,7 @@ interface CycleTimeRow {
     labels: string,
     count: number,
     cycleTimeInDays: string,
-    limit: number
+    limit: string,
 }
 
 export interface IssueCardCycleTime extends ProjectIssue {
@@ -85,7 +85,7 @@ export function renderMarkdown(projData: ProjectData, processedData: any): strin
     ctRow.labels = `\`${cardType}\``;
     ctRow.count = stageData.count;
     ctRow.cycleTimeInDays = ` ${stageData.cycletime ? stageData.cycletime.toFixed(2):""} ${stageData.flag ? ":triangular_flag_on_post:": ""}`;
-    ctRow.limit = stageData.limit;
+    ctRow.limit = stageData.limit >= 0? stageData.limit.toString() : "";
     rows.push(ctRow);
   }
 


### PR DESCRIPTION
Allows for mappings to handling inexact settings.  It looks for the column to have all the words mentioned in the mapping.

We also used to only crawl columns mentioned in the mappings which was problematic since a small typo would exclude potential issues that had invalid / not mentioned mappings.  Now, we iterate over all the columns on the board which is also better at alerting to issues which have columns not mentioned or mapped at all.

<img width="634" alt="Screen Shot 2020-08-15 at 7 53 28 AM" src="https://user-images.githubusercontent.com/919564/90398696-d8b1b680-e067-11ea-9477-f6ae4815d05d.png">
