### PR TITLE
Exit with an error code "1" when GHPAT is not set

### DIFF
--- a/interactive.sh
+++ b/interactive.sh
@@ -11,7 +11,7 @@ export INPUT_CONFIGPATH=${1:-samples/sample.yaml}
 echo "Running ${INPUT_CONFIGPATH}"
 
 [ -n "${GHPAT}" ] || { 
-    echo "set GHPAT envvar" && exit 
+    echo "set GHPAT envvar" && exit  1
 }
 
 export GITHUB_WORKSPACE="${SCRIPT_DIR}"


### PR DESCRIPTION
This tripped me up and I hadn't realized an error had occurred. The `exit 1` will make it clearer that something went wrong and that `GHPAT` is required.