### PR TITLE
Add noEmit to tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-*.js
-*.js.map
 !dist/**/*.js
 !jest.config.js
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-!dist/**/*.js
-!jest.config.js
 node_modules/
 _cache
 # interactive running

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest",
     "check:format": "prettier --write *.ts **/*.ts",
     "check:lint": "eslint *.ts **/*.ts __tests__ github reports types",
-    "check": "run-s check:format check:lint"
+    "check:compile": "tsc",
+    "check": "run-s check:format check:lint check:compile"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
+    "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */


### PR DESCRIPTION
This adds `noEmit` to tsconfig.json and removes `.js` and `.js.map` from .gitignore.

Additionally it adds a `tsc` compilation check to the pre-commit hooks. We can do this now that `tsc` produces no output.

After pulling this change locally, you'll need to manually delete the leftover `.js*` files, but it takes just moment.