### PR TITLE
Use ISO 8601 for encoding datetimes

### DIFF
--- a/generator.ts
+++ b/generator.ts
@@ -41,6 +41,13 @@ export async function generate(
 
   const snapshot = <ReportSnapshot>{}
   snapshot.datetime = new Date()
+
+  // ISO8601 without separators—supported by moment, etc.
+  snapshot.datetimeString = snapshot.datetime
+    .toISOString()
+    .replace(/:/g, '')
+    .replace(/-/g, '')
+
   snapshot.config = config
 
   snapshot.config.output = snapshot.config.output || '_reports'
@@ -64,7 +71,7 @@ export async function generate(
     )
     report.details.fullPath = path.join(
       report.details.rootPath,
-      snapshot.datetime.toISOString()
+      snapshot.datetimeString
     )
     report.details.dataPath = path.join(report.details.fullPath, 'data')
 
@@ -337,10 +344,7 @@ async function writeSnapshot(snapshot: ReportSnapshot) {
   const genPath = path.join(snapshot.rootPath, '.data')
   util.mkdirP(genPath)
 
-  const snapshotPath = path.join(
-    genPath,
-    `${snapshot.datetime.toISOString()}.json`
-  )
+  const snapshotPath = path.join(genPath, `${snapshot.datetimeString}.json`)
   console.log(`Writing to ${snapshotPath}`)
 
   fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2))

--- a/generator.ts
+++ b/generator.ts
@@ -42,14 +42,6 @@ export async function generate(
   const snapshot = <ReportSnapshot>{}
   snapshot.datetime = new Date()
   snapshot.config = config
-  const d = snapshot.datetime
-  const year = d.getUTCFullYear()
-  const month = (d.getUTCMonth() + 1).toString().padStart(2, '0')
-  const day = d.getUTCDate().toString().padStart(2, '0')
-  const hour = d.getUTCHours().toString().padStart(2, '0')
-  const minute = d.getUTCMinutes().toString().padStart(2, '0')
-  const dt = `${year}-${month}-${day}_${hour}-${minute}`
-  snapshot.datetimeString = dt
 
   snapshot.config.output = snapshot.config.output || '_reports'
   snapshot.rootPath = path.join(workspacePath, snapshot.config.output)
@@ -72,7 +64,7 @@ export async function generate(
     )
     report.details.fullPath = path.join(
       report.details.rootPath,
-      snapshot.datetimeString
+      snapshot.datetime.toISOString()
     )
     report.details.dataPath = path.join(report.details.fullPath, 'data')
 
@@ -345,7 +337,10 @@ async function writeSnapshot(snapshot: ReportSnapshot) {
   const genPath = path.join(snapshot.rootPath, '.data')
   util.mkdirP(genPath)
 
-  const snapshotPath = path.join(genPath, `${snapshot.datetimeString}.json`)
+  const snapshotPath = path.join(
+    genPath,
+    `${snapshot.datetime.toISOString()}.json`
+  )
   console.log(`Writing to ${snapshotPath}`)
 
   fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2))

--- a/generator.ts
+++ b/generator.ts
@@ -43,10 +43,9 @@ export async function generate(
   snapshot.datetime = new Date()
 
   // ISO8601 without separators—supported by moment, etc.
-  snapshot.datetimeString = snapshot.datetime
-    .toISOString()
-    .replace(/:/g, '')
-    .replace(/-/g, '')
+  snapshot.datetimeString = moment(snapshot.datetime)
+    .utc()
+    .format('YYYYMMDDTHHmmss.SSS[Z]')
 
   snapshot.config = config
 

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -49,7 +49,6 @@ export interface ReportSnapshotData {
 
 export interface ReportSnapshot {
   datetime: Date
-  datetimeString: string
   rootPath: string
   config: GeneratorConfiguration
 }

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -49,6 +49,7 @@ export interface ReportSnapshotData {
 
 export interface ReportSnapshot {
   datetime: Date
+  datetimeString: string
   rootPath: string
   config: GeneratorConfiguration
 }


### PR DESCRIPTION
This is just a suggestion! Let me know what you think. Not knowing the custom datetime format used in the generator, I had trouble understanding the directory names. Separator-less ISO 8601 datetime strings (a valid variant of ISO 8601) are also valid directory/file names, so I'm thinking maybe we can use them instead.

An example timestamp:

`20200820T145028.332Z`

This also means that other software consuming these dates can parse them with moment.js.