### PR TITLE
get field from last comment

### DIFF
--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -158,9 +158,9 @@ describe('report-lib', () => {
 
   it('gets last comments date field value from issue', async () => {
     const v = rptLib.getLastCommentDateField(card, 'target date')
-    expect(v.getUTCMonth()).toBe(7); // 0 based
-    expect(v.getUTCDate()).toBe(4);
-    expect(v.getUTCFullYear()).toBe(2020);
+    expect(v.getUTCMonth()).toBe(7) // 0 based
+    expect(v.getUTCDate()).toBe(4)
+    expect(v.getUTCFullYear()).toBe(2020)
   })
 
   it('handles no comments for field date value from issue', async () => {
@@ -169,6 +169,19 @@ describe('report-lib', () => {
       'target date'
     )
     expect(v).toBeFalsy()
+  })
+
+  it('handles invalid dates for field date value from issue', async () => {
+    const v = rptLib.getLastCommentDateField(
+      <ProjectIssue>{
+        comments: [{
+          body: ' target date : 13-13-20 '
+        }]
+      },
+      'target date'
+    ) as Date
+
+    expect(v.valueOf()).toBe(NaN);
   })
 
   it('gets last comment updated_at value from dataFromCard', async () => {

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -116,6 +116,12 @@ describe('report-lib', () => {
         updated_at: new Date('2020-07-23T03:29:07.282Z')
       },
       {
+        body: ' foo: bar '
+      },
+      {
+        body: ' target date : 8-4-20 '
+      },
+      {
         body: '## update 3',
         updated_at: new Date('2020-07-23T03:31:35.918Z')
       }
@@ -140,12 +146,36 @@ describe('report-lib', () => {
     expect(d).toBeFalsy()
   })
 
+  it('gets last comments field value from issue', async () => {
+    const v = rptLib.getLastCommentField(card, 'foo')
+    expect(v).toBe('bar')
+  })
+
+  it('handles no comments for field value from issue', async () => {
+    const v = rptLib.getLastCommentField(<ProjectIssue>{comments: []}, 'foo')
+    expect(v).toBeFalsy()
+  })
+
+  it('gets last comments date field value from issue', async () => {
+    const v = rptLib.getLastCommentDateField(card, 'target date')
+    expect(v.toISOString()).toBe('2020-08-04T04:00:00.000Z')
+  })
+
+  it('handles no comments for field date value from issue', async () => {
+    const v = rptLib.getLastCommentDateField(
+      <ProjectIssue>{comments: []},
+      'target date'
+    )
+    expect(v).toBeFalsy()
+  })
+
   it('gets last comment updated_at value from dataFromCard', async () => {
     const d = rptLib.dataFromCard(
       card,
       'LastCommentPattern',
       '^(#){1,4} update'
     )
+    console.log(d)
     expect(d.toISOString()).toBe('2020-07-23T03:31:35.918Z')
   })
 

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -1,27 +1,27 @@
 import * as rptLib from '../project-reports-lib'
-import {IssueList, ProjectIssue} from '../project-reports-lib'
+import { IssueList, ProjectIssue } from '../project-reports-lib'
 import projectData from './project-data.test.json'
 
 const testCards: ProjectIssue[] = [
   <ProjectIssue>{
     number: 1,
     title: 'one',
-    labels: [{name: 'One'}]
+    labels: [{ name: 'One' }]
   },
   <ProjectIssue>{
     number: 2,
     title: 'twothree',
-    labels: [{name: 'Two'}, {name: 'three'}]
+    labels: [{ name: 'Two' }, { name: 'three' }]
   },
   <ProjectIssue>{
     number: 3,
     title: 'other',
-    labels: [{name: 'two'}, {name: '11-dev'}, {name: 'foo:baz'}]
+    labels: [{ name: 'two' }, { name: '11-dev' }, { name: 'foo:baz' }]
   },
   <ProjectIssue>{
     number: 4,
     title: 'more',
-    labels: [{name: 'five'}, {name: '13-DEV'}, {name: 'Foo: bar '}]
+    labels: [{ name: 'five' }, { name: '13-DEV' }, { name: 'Foo: bar ' }]
   }
 ]
 
@@ -140,7 +140,7 @@ describe('report-lib', () => {
 
   it('does not gets last comment if no comments', async () => {
     const d = rptLib.getLastCommentPattern(
-      <ProjectIssue>{comments: []},
+      <ProjectIssue>{ comments: [] },
       '^(#){1,4} update'
     )
     expect(d).toBeFalsy()
@@ -152,18 +152,18 @@ describe('report-lib', () => {
   })
 
   it('handles no comments for field value from issue', async () => {
-    const v = rptLib.getLastCommentField(<ProjectIssue>{comments: []}, 'foo')
+    const v = rptLib.getLastCommentField(<ProjectIssue>{ comments: [] }, 'foo')
     expect(v).toBeFalsy()
   })
 
   it('gets last comments date field value from issue', async () => {
     const v = rptLib.getLastCommentDateField(card, 'target date')
-    expect(v.toISOString()).toBe('2020-08-04T04:00:00.000Z')
+    expect(v.toUTCString()).toBe('Tue, 04 Aug 2020 04:00:00 GMT')
   })
 
   it('handles no comments for field date value from issue', async () => {
     const v = rptLib.getLastCommentDateField(
-      <ProjectIssue>{comments: []},
+      <ProjectIssue>{ comments: [] },
       'target date'
     )
     expect(v).toBeFalsy()
@@ -184,22 +184,22 @@ describe('report-lib', () => {
     expect(set).toBeDefined()
     expect(set.getItems().length).toBe(0)
 
-    let added = set.add({name: 'one', number: 1})
+    let added = set.add({ name: 'one', number: 1 })
     expect(added).toBeTruthy()
     expect(set.getItems().length).toBe(1)
 
-    added = set.add({name: 'two', number: 2})
+    added = set.add({ name: 'two', number: 2 })
     expect(added).toBeTruthy()
     expect(set.getItems().length).toBe(2)
 
-    added = set.add({name: 'dupe', number: 1})
+    added = set.add({ name: 'dupe', number: 1 })
     expect(added).toBeFalsy()
     expect(set.getItems().length).toBe(2)
 
     added = set.add([
-      {name: 'three', number: 3},
-      {name: 'four', number: 4},
-      {name: 'dupe', number: 1}
+      { name: 'three', number: 3 },
+      { name: 'four', number: 4 },
+      { name: 'dupe', number: 1 }
     ])
     expect(added).toBeTruthy()
     expect(set.getItems().length).toBe(4)

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -158,7 +158,9 @@ describe('report-lib', () => {
 
   it('gets last comments date field value from issue', async () => {
     const v = rptLib.getLastCommentDateField(card, 'target date')
-    expect(v.toUTCString()).toBe('Tue, 04 Aug 2020 04:00:00 GMT')
+    expect(v.getUTCMonth()).toBe(7); // 0 based
+    expect(v.getUTCDate()).toBe(4);
+    expect(v.getUTCFullYear()).toBe(2020);
   })
 
   it('handles no comments for field date value from issue', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3119,8 +3119,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -3139,14 +3139,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3055,9 +3055,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(97));
 const moment_1 = __importDefault(__webpack_require__(482));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(112), exports);
@@ -3113,6 +3114,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-cycle-time/index.js
+++ b/dist/reports/project-cycle-time/index.js
@@ -169,8 +169,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -189,14 +189,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-cycle-time/index.js
+++ b/dist/reports/project-cycle-time/index.js
@@ -105,9 +105,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(263));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -163,6 +164,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-done/index.js
+++ b/dist/reports/project-done/index.js
@@ -169,8 +169,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -189,14 +189,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-done/index.js
+++ b/dist/reports/project-done/index.js
@@ -105,9 +105,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(263));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -163,6 +164,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-groupby-status/index.js
+++ b/dist/reports/project-groupby-status/index.js
@@ -627,8 +627,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -647,14 +647,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-groupby-status/index.js
+++ b/dist/reports/project-groupby-status/index.js
@@ -563,9 +563,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(97));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -621,6 +622,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-in-progress/index.js
+++ b/dist/reports/project-in-progress/index.js
@@ -641,8 +641,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -661,14 +661,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-in-progress/index.js
+++ b/dist/reports/project-in-progress/index.js
@@ -577,9 +577,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(97));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -635,6 +636,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-limits/index.js
+++ b/dist/reports/project-limits/index.js
@@ -425,8 +425,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -445,14 +445,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-limits/index.js
+++ b/dist/reports/project-limits/index.js
@@ -361,9 +361,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(97));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -419,6 +420,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/project-new/index.js
+++ b/dist/reports/project-new/index.js
@@ -169,8 +169,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -189,14 +189,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/project-new/index.js
+++ b/dist/reports/project-new/index.js
@@ -105,9 +105,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(263));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -163,6 +164,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/dist/reports/repo-issues/index.js
+++ b/dist/reports/repo-issues/index.js
@@ -425,8 +425,8 @@ function getLastCommentField(issue, field) {
     if (!issue.comments) {
         return '';
     }
-    while (true) {
-        const comment = issue.comments.pop();
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i];
         if (!comment) {
             break;
         }
@@ -445,14 +445,13 @@ function getLastCommentField(issue, field) {
     return val;
 }
 exports.getLastCommentField = getLastCommentField;
-// returns a valid date field value from a comment field 
+// returns a valid date field value from a comment field
 function getLastCommentDateField(issue, field) {
     let d = null;
-    let val = getLastCommentField(issue, field);
-    try {
+    const val = getLastCommentField(issue, field);
+    if (val) {
         d = new Date(val);
     }
-    catch (_a) { }
     return d;
 }
 exports.getLastCommentDateField = getLastCommentDateField;

--- a/dist/reports/repo-issues/index.js
+++ b/dist/reports/repo-issues/index.js
@@ -361,9 +361,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
+exports.IssueList = exports.getProjectStageIssues = exports.ProjectStages = exports.fuzzyMatch = exports.sumCardProperty = exports.getLastCommentDateField = exports.getLastCommentField = exports.getStringFromLabel = exports.getCountFromLabel = exports.filterByLabel = exports.repoPropsFromUrl = void 0;
 const clone_1 = __importDefault(__webpack_require__(97));
 const moment_1 = __importDefault(__webpack_require__(431));
+const os = __importStar(__webpack_require__(87));
 const url = __importStar(__webpack_require__(835));
 // TODO: separate npm module.  for now it's a file till we flush out
 __exportStar(__webpack_require__(385), exports);
@@ -419,6 +420,42 @@ function getStringFromLabel(card, re) {
     return str;
 }
 exports.getStringFromLabel = getStringFromLabel;
+function getLastCommentField(issue, field) {
+    let val = '';
+    if (!issue.comments) {
+        return '';
+    }
+    while (true) {
+        const comment = issue.comments.pop();
+        if (!comment) {
+            break;
+        }
+        const lines = comment.body.split(os.EOL);
+        for (const line of lines) {
+            const parts = line.trim().split(':');
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim();
+                break;
+            }
+        }
+        if (val) {
+            break;
+        }
+    }
+    return val;
+}
+exports.getLastCommentField = getLastCommentField;
+// returns a valid date field value from a comment field 
+function getLastCommentDateField(issue, field) {
+    let d = null;
+    let val = getLastCommentField(issue, field);
+    try {
+        d = new Date(val);
+    }
+    catch (_a) { }
+    return d;
+}
+exports.getLastCommentDateField = getLastCommentDateField;
 function sumCardProperty(cards, prop) {
     return cards.reduce((a, b) => a + (b[prop] || 0), 0);
 }

--- a/project-reports-lib.ts
+++ b/project-reports-lib.ts
@@ -8,32 +8,32 @@ import * as url from 'url'
 export * from './project-reports-schemes'
 
 export interface RepoProps {
-    owner: string
-    repo: string
+  owner: string
+  repo: string
 }
 
 export function repoPropsFromUrl(htmlUrl: string): RepoProps {
-    const rUrl = new url.URL(htmlUrl)
-    const parts = rUrl.pathname.split('/').filter(e => e)
+  const rUrl = new url.URL(htmlUrl)
+  const parts = rUrl.pathname.split('/').filter(e => e)
 
-    return <RepoProps>{
-        owner: parts[0],
-        repo: parts[1]
-    }
+  return <RepoProps>{
+    owner: parts[0],
+    repo: parts[1]
+  }
 }
 //
 // filter cards by label
 //
 export function filterByLabel(
-    issues: ProjectIssue[],
-    name: string
+  issues: ProjectIssue[],
+  name: string
 ): ProjectIssue[] {
-    return issues.filter(
-        card =>
-            card.labels.findIndex(
-                label => label.name.trim().toLowerCase() === name.toLowerCase()
-            ) >= 0
-    )
+  return issues.filter(
+    card =>
+      card.labels.findIndex(
+        label => label.name.trim().toLowerCase() === name.toLowerCase()
+      ) >= 0
+  )
 }
 
 //
@@ -42,484 +42,484 @@ export function filterByLabel(
 // returns NaN if no labels match
 //
 export function getCountFromLabel(card: ProjectIssue, re: RegExp): number {
-    let num = NaN
+  let num = NaN
 
-    for (const label of card.labels) {
-        const matches = label.name.match(re)
-        if (matches && matches.length > 0) {
-            num = parseInt(matches[1])
-            if (num) {
-                break
-            }
-        }
+  for (const label of card.labels) {
+    const matches = label.name.match(re)
+    if (matches && matches.length > 0) {
+      num = parseInt(matches[1])
+      if (num) {
+        break
+      }
     }
-    return num
+  }
+  return num
 }
 
 export function getStringFromLabel(card: ProjectIssue, re: RegExp): string {
-    let str = ''
+  let str = ''
 
-    for (const label of card.labels) {
-        const matches = label.name.trim().match(re)
-        if (matches && matches.length > 0) {
-            str = matches[0]
-            if (str) {
-                break
-            }
-        }
+  for (const label of card.labels) {
+    const matches = label.name.trim().match(re)
+    if (matches && matches.length > 0) {
+      str = matches[0]
+      if (str) {
+        break
+      }
     }
+  }
 
-    if (str) {
-        str = str.trim()
-    }
+  if (str) {
+    str = str.trim()
+  }
 
-    return str
+  return str
 }
 
 export function getLastCommentField(
-    issue: ProjectIssue,
-    field: string
+  issue: ProjectIssue,
+  field: string
 ): string {
-    let val = ''
+  let val = ''
 
-    if (!issue.comments) {
-        return ''
+  if (!issue.comments) {
+    return ''
+  }
+
+  for (let i = issue.comments.length - 1; i >= 0; i--) {
+    const comment = issue.comments[i]
+    if (!comment) {
+      break
     }
 
-    for (let i = issue.comments.length - 1; i >= 0; i--) {
-        const comment = issue.comments[i]
-        if (!comment) {
-            break
-        }
-
-        const lines = comment.body.split(os.EOL)
-        for (const line of lines) {
-            const parts = line.trim().split(':')
-            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
-                val = parts[1].trim()
-                break
-            }
-        }
-
-        if (val) {
-            break
-        }
+    const lines = comment.body.split(os.EOL)
+    for (const line of lines) {
+      const parts = line.trim().split(':')
+      if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+        val = parts[1].trim()
+        break
+      }
     }
 
-    return val
+    if (val) {
+      break
+    }
+  }
+
+  return val
 }
 
 // returns a valid date field value from a comment field
 export function getLastCommentDateField(
-    issue: ProjectIssue,
-    field: string
+  issue: ProjectIssue,
+  field: string
 ): Date {
-    let d: Date = null
-    const val = getLastCommentField(issue, field)
+  let d: Date = null
+  const val = getLastCommentField(issue, field)
 
-    try {
-        if (val) {
-            d = new Date(val)
-        }
-    } catch (err) {
-        // if not a valid date, will return null date
+  try {
+    if (val) {
+      d = new Date(val)
     }
+  } catch (err) {
+    // if not a valid date, will return null date
+  }
 
-    return d
+  return d
 }
 
 export function sumCardProperty(cards: ProjectIssue[], prop: string): number {
-    return cards.reduce((a, b) => a + (b[prop] || 0), 0)
+  return cards.reduce((a, b) => a + (b[prop] || 0), 0)
 }
 
 export function fuzzyMatch(content: string, match: string): boolean {
-    let matchWords = match.match(/[a-zA-Z0-9]+/g)
-    matchWords = matchWords.map(item => item.toLowerCase())
+  let matchWords = match.match(/[a-zA-Z0-9]+/g)
+  matchWords = matchWords.map(item => item.toLowerCase())
 
-    let contentWords = content.match(/[a-zA-Z0-9]+/g)
-    contentWords = contentWords.map(item => item.toLowerCase())
+  let contentWords = content.match(/[a-zA-Z0-9]+/g)
+  contentWords = contentWords.map(item => item.toLowerCase())
 
-    let isMatch = true
-    for (const matchWord of matchWords) {
-        if (contentWords.indexOf(matchWord) === -1) {
-            isMatch = false
-            break
-        }
+  let isMatch = true
+  for (const matchWord of matchWords) {
+    if (contentWords.indexOf(matchWord) === -1) {
+      isMatch = false
+      break
     }
-    return isMatch
+  }
+  return isMatch
 }
 
 // Project issues keyed by the stage they are in
 export interface ProjectIssues {
-    stages: { [key: string]: ProjectIssue[] }
+  stages: {[key: string]: ProjectIssue[]}
 }
 
 export interface ProjectColumn {
-    cards_url: string
-    id: number
-    name: string
+  cards_url: string
+  id: number
+  name: string
 }
 
 // stages more discoverable
 export const ProjectStages = {
-    Proposed: 'Proposed',
-    Accepted: 'Accepted',
-    InProgress: 'In-Progress',
-    Done: 'Done',
-    Missing: 'Missing'
+  Proposed: 'Proposed',
+  Accepted: 'Accepted',
+  InProgress: 'In-Progress',
+  Done: 'Done',
+  Missing: 'Missing'
 }
 
-export type ProjectStageIssues = { [key: string]: ProjectIssue[] }
+export type ProjectStageIssues = {[key: string]: ProjectIssue[]}
 
 export function getProjectStageIssues(issues: ProjectIssue[]) {
-    const projIssues = <ProjectStageIssues>{}
-    for (const projIssue of issues) {
-        const stage = projIssue['project_stage']
-        if (!stage) {
-            // the engine will handle and add to an issues list
-            continue
-        }
-
-        if (!projIssues[stage]) {
-            projIssues[stage] = []
-        }
-
-        projIssues[stage].push(projIssue)
+  const projIssues = <ProjectStageIssues>{}
+  for (const projIssue of issues) {
+    const stage = projIssue['project_stage']
+    if (!stage) {
+      // the engine will handle and add to an issues list
+      continue
     }
 
-    return projIssues
+    if (!projIssues[stage]) {
+      projIssues[stage] = []
+    }
+
+    projIssues[stage].push(projIssue)
+  }
+
+  return projIssues
 }
 
 export interface IssueLabel {
-    name: string
+  name: string
 }
 
 export interface IssueCardEventProject {
-    project_id: number
-    column_name: string
-    previous_column_name: string
-    stage_name: string
-    previous_stage_name: string
+  project_id: number
+  column_name: string
+  previous_column_name: string
+  stage_name: string
+  previous_stage_name: string
 }
 
 export interface IssueEvent {
-    created_at: Date
-    event: string
-    assignee: IssueUser
-    label: IssueLabel
-    project_card: IssueCardEventProject
-    //data: any
+  created_at: Date
+  event: string
+  assignee: IssueUser
+  label: IssueLabel
+  project_card: IssueCardEventProject
+  //data: any
 }
 
 export interface IssueUser {
-    login: string
-    id: number
-    avatar_url: string
-    url: string
-    html_url: string
+  login: string
+  id: number
+  avatar_url: string
+  url: string
+  html_url: string
 }
 
 export interface IssueMilestone {
-    title: string
-    description: string
-    due_on: Date
+  title: string
+  description: string
+  due_on: Date
 }
 
 export interface IssueComment {
-    body: string
-    user: IssueUser
-    created_at: Date
-    updated_at: Date
+  body: string
+  user: IssueUser
+  created_at: Date
+  updated_at: Date
 }
 
 export interface ProjectIssue {
-    title: string
-    number: number
-    html_url: string
-    state: string
-    labels: IssueLabel[]
-    assignee: IssueUser
-    assignees: IssueUser[]
-    user: IssueUser
-    milestone: IssueMilestone
-    closed_at: Date
-    created_at: Date
-    updated_at: Date
+  title: string
+  number: number
+  html_url: string
+  state: string
+  labels: IssueLabel[]
+  assignee: IssueUser
+  assignees: IssueUser[]
+  user: IssueUser
+  milestone: IssueMilestone
+  closed_at: Date
+  created_at: Date
+  updated_at: Date
 
-    comments: IssueComment[]
-    events: IssueEvent[]
+  comments: IssueComment[]
+  events: IssueEvent[]
 
-    //
-    // project stage fields we decorate on issues
-    //
+  //
+  // project stage fields we decorate on issues
+  //
 
-    // first added to the board on any column (no "from" column)
-    project_added_at: Date
+  // first added to the board on any column (no "from" column)
+  project_added_at: Date
 
-    // last occurence of moving to these columns from a lesser or no column
-    // example. if moved to accepted from proposed (or less),
-    //      then in-progress (greater) and then back to accepted, first wins
-    project_proposed_at: Date
-    project_accepted_at: Date
-    project_in_progress_at: Date
+  // last occurence of moving to these columns from a lesser or no column
+  // example. if moved to accepted from proposed (or less),
+  //      then in-progress (greater) and then back to accepted, first wins
+  project_proposed_at: Date
+  project_accepted_at: Date
+  project_in_progress_at: Date
 
-    // cleared if not currently blocked
-    project_blocked_at: Date
+  // cleared if not currently blocked
+  project_blocked_at: Date
 
-    // cleared if it moves out of done.  e.g. current state has to be done for this to be set
-    project_done_at: Date
+  // cleared if it moves out of done.  e.g. current state has to be done for this to be set
+  project_done_at: Date
 
-    // current stage of this card on the board
-    project_stage: string
+  // current stage of this card on the board
+  project_stage: string
 }
 
 const stageLevel = {
-    None: 0,
-    Proposed: 1,
-    Accepted: 2,
-    'In-Progress': 3,
-    Done: 4,
-    Unmapped: 5
+  None: 0,
+  Proposed: 1,
+  Accepted: 2,
+  'In-Progress': 3,
+  Done: 4,
+  Unmapped: 5
 }
 
 export class IssueList {
-    seen
-    identifier
-    items: ProjectIssue[]
-    processed: ProjectIssue[]
+  seen
+  identifier
+  items: ProjectIssue[]
+  processed: ProjectIssue[]
 
-    // keep in order indexed by level above
-    // TODO: unify both to avoid out of sync problems
-    stageAtNames = [
-        'none',
-        'project_proposed_at',
-        'project_accepted_at',
-        'project_in_progress_at',
-        'project_done_at'
-    ]
+  // keep in order indexed by level above
+  // TODO: unify both to avoid out of sync problems
+  stageAtNames = [
+    'none',
+    'project_proposed_at',
+    'project_accepted_at',
+    'project_in_progress_at',
+    'project_done_at'
+  ]
 
-    constructor(identifier: (item) => any) {
-        this.seen = new Map()
-        this.identifier = identifier
-        this.items = []
+  constructor(identifier: (item) => any) {
+    this.seen = new Map()
+    this.identifier = identifier
+    this.items = []
+  }
+
+  // returns whether any were added
+  public add(data: any | any[]): boolean {
+    this.processed = null
+    let added = false
+    if (Array.isArray(data)) {
+      for (const item of data) {
+        const res = this.add_item(item)
+        if (!added) {
+          added = res
+        }
+      }
+    } else {
+      return this.add_item(data)
     }
 
-    // returns whether any were added
-    public add(data: any | any[]): boolean {
-        this.processed = null
-        let added = false
-        if (Array.isArray(data)) {
-            for (const item of data) {
-                const res = this.add_item(item)
-                if (!added) {
-                    added = res
-                }
+    return added
+  }
+
+  private add_item(item: any): boolean {
+    const id = this.identifier(item)
+
+    if (!this.seen.has(id)) {
+      this.items.push(item)
+      this.seen.set(id, item)
+      return true
+    }
+
+    return false
+  }
+
+  public getItem(identifier: any): ProjectIssue {
+    return this.seen.get(identifier)
+  }
+
+  public getItems(): ProjectIssue[] {
+    if (this.processed) {
+      return this.processed
+    }
+
+    // call process
+    for (const item of this.items) {
+      this.processStages(item)
+    }
+
+    this.processed = this.items
+    return this.processed
+  }
+
+  //
+  // Gets an issue from a number of days, hours ago.
+  // Clones the issue and Replays events (labels, column moves, milestones)
+  // and reprocesses the stages.
+  // If the issue doesn't exist in the list, returns null
+  //
+  public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
+    console.log(`getting asof ${datetime} : ${identifier}`)
+    let issue = this.getItem(identifier)
+
+    if (!issue) {
+      return issue
+    }
+
+    issue = clone(issue)
+    const momentAgo = moment(datetime)
+
+    // clear everything we're going to re-apply
+    issue.labels = []
+    delete issue.project_added_at
+    delete issue.project_proposed_at
+    delete issue.project_in_progress_at
+    delete issue.project_accepted_at
+    delete issue.project_done_at
+    delete issue.project_stage
+    delete issue.closed_at
+
+    // stages and labels
+    const filteredEvents: IssueEvent[] = []
+    const labelMap: {[name: string]: IssueLabel} = {}
+
+    if (issue.events) {
+      for (const event of issue.events) {
+        if (moment(event.created_at).isAfter(momentAgo)) {
+          continue
+        }
+
+        filteredEvents.push(event)
+
+        if (event.event === 'labeled') {
+          labelMap[event.label.name] = event.label
+        } else if (event.event === 'unlabeled') {
+          delete labelMap[event.label.name]
+        }
+
+        if (event.event === 'closed') {
+          issue.closed_at = event.created_at
+        }
+
+        if (event.event === 'reopened') {
+          delete issue.closed_at
+        }
+      }
+    }
+    issue.events = filteredEvents
+
+    for (const labelName in labelMap) {
+      issue.labels.push(labelMap[labelName])
+    }
+
+    this.processStages(issue)
+
+    // comments
+    const filteredComments: IssueComment[] = []
+    for (const comment of issue.comments) {
+      if (moment(comment.created_at).isAfter(momentAgo)) {
+        continue
+      }
+
+      filteredComments.push(comment)
+    }
+    issue.comments = filteredComments
+
+    return issue
+  }
+
+  //
+  // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
+  // Call initially and then call again if events are filtered (get issue asof)
+  //
+  private processStages(issue: ProjectIssue): void {
+    console.log(`Processing stages for ${issue.html_url}`)
+    // card events should be in order chronologically
+    let currentStage: string
+    let doneTime: Date
+    let addedTime: Date
+
+    const tempLabels = {}
+
+    if (issue.events) {
+      for (const event of issue.events) {
+        let eventDateTime: Date
+        if (event.created_at) {
+          eventDateTime = event.created_at
+        }
+
+        //
+        // Process Project Stages
+        //
+        let toStage: string
+        let toLevel: number
+        let fromStage: string
+        let fromLevel = 0
+
+        if (event.project_card && event.project_card.column_name) {
+          if (!addedTime) {
+            addedTime = eventDateTime
+          }
+
+          if (!event.project_card.stage_name) {
+            throw new Error(
+              `stage_name should have been set already for ${event.project_card.column_name}`
+            )
+          }
+
+          toStage = event.project_card.stage_name
+          toLevel = stageLevel[toStage]
+          currentStage = toStage
+        }
+
+        if (event.project_card && event.project_card.previous_column_name) {
+          if (!event.project_card.previous_stage_name) {
+            throw new Error(
+              `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
+            )
+          }
+
+          fromStage = event.project_card.previous_stage_name
+          fromLevel = stageLevel[fromStage]
+        }
+
+        // last occurence of moving to these columns from a lesser or no column
+        // example. if moved to accepted from proposed (or less),
+        //      then in-progress (greater) and then back to accepted, first wins
+        if (
+          toStage === 'Proposed' ||
+          toStage === 'Accepted' ||
+          toStage === 'In-Progress'
+        ) {
+          if (toLevel > fromLevel) {
+            issue[this.stageAtNames[toLevel]] = eventDateTime
+          }
+          //moving back, clear the stage at dates up to fromLevel
+          else if (toLevel < fromLevel) {
+            for (let i = toLevel + 1; i <= fromLevel; i++) {
+              delete issue[this.stageAtNames[i]]
             }
-        } else {
-            return this.add_item(data)
+          }
         }
 
-        return added
+        if (toStage === 'Done') {
+          doneTime = eventDateTime
+        }
+      }
+
+      // done_at and blocked_at is only set if it's currently at that stage
+      if (currentStage === 'Done') {
+        issue.project_done_at = doneTime
+        console.log(`project_done_at: ${issue.project_done_at}`)
+      }
+
+      if (addedTime) {
+        issue.project_added_at = addedTime
+        console.log(`project_added_at: ${issue.project_added_at}`)
+      }
+
+      issue.project_stage = currentStage
+      console.log(`project_stage: ${issue.project_stage}`)
     }
-
-    private add_item(item: any): boolean {
-        const id = this.identifier(item)
-
-        if (!this.seen.has(id)) {
-            this.items.push(item)
-            this.seen.set(id, item)
-            return true
-        }
-
-        return false
-    }
-
-    public getItem(identifier: any): ProjectIssue {
-        return this.seen.get(identifier)
-    }
-
-    public getItems(): ProjectIssue[] {
-        if (this.processed) {
-            return this.processed
-        }
-
-        // call process
-        for (const item of this.items) {
-            this.processStages(item)
-        }
-
-        this.processed = this.items
-        return this.processed
-    }
-
-    //
-    // Gets an issue from a number of days, hours ago.
-    // Clones the issue and Replays events (labels, column moves, milestones)
-    // and reprocesses the stages.
-    // If the issue doesn't exist in the list, returns null
-    //
-    public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
-        console.log(`getting asof ${datetime} : ${identifier}`)
-        let issue = this.getItem(identifier)
-
-        if (!issue) {
-            return issue
-        }
-
-        issue = clone(issue)
-        const momentAgo = moment(datetime)
-
-        // clear everything we're going to re-apply
-        issue.labels = []
-        delete issue.project_added_at
-        delete issue.project_proposed_at
-        delete issue.project_in_progress_at
-        delete issue.project_accepted_at
-        delete issue.project_done_at
-        delete issue.project_stage
-        delete issue.closed_at
-
-        // stages and labels
-        const filteredEvents: IssueEvent[] = []
-        const labelMap: { [name: string]: IssueLabel } = {}
-
-        if (issue.events) {
-            for (const event of issue.events) {
-                if (moment(event.created_at).isAfter(momentAgo)) {
-                    continue
-                }
-
-                filteredEvents.push(event)
-
-                if (event.event === 'labeled') {
-                    labelMap[event.label.name] = event.label
-                } else if (event.event === 'unlabeled') {
-                    delete labelMap[event.label.name]
-                }
-
-                if (event.event === 'closed') {
-                    issue.closed_at = event.created_at
-                }
-
-                if (event.event === 'reopened') {
-                    delete issue.closed_at
-                }
-            }
-        }
-        issue.events = filteredEvents
-
-        for (const labelName in labelMap) {
-            issue.labels.push(labelMap[labelName])
-        }
-
-        this.processStages(issue)
-
-        // comments
-        const filteredComments: IssueComment[] = []
-        for (const comment of issue.comments) {
-            if (moment(comment.created_at).isAfter(momentAgo)) {
-                continue
-            }
-
-            filteredComments.push(comment)
-        }
-        issue.comments = filteredComments
-
-        return issue
-    }
-
-    //
-    // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
-    // Call initially and then call again if events are filtered (get issue asof)
-    //
-    private processStages(issue: ProjectIssue): void {
-        console.log(`Processing stages for ${issue.html_url}`)
-        // card events should be in order chronologically
-        let currentStage: string
-        let doneTime: Date
-        let addedTime: Date
-
-        const tempLabels = {}
-
-        if (issue.events) {
-            for (const event of issue.events) {
-                let eventDateTime: Date
-                if (event.created_at) {
-                    eventDateTime = event.created_at
-                }
-
-                //
-                // Process Project Stages
-                //
-                let toStage: string
-                let toLevel: number
-                let fromStage: string
-                let fromLevel = 0
-
-                if (event.project_card && event.project_card.column_name) {
-                    if (!addedTime) {
-                        addedTime = eventDateTime
-                    }
-
-                    if (!event.project_card.stage_name) {
-                        throw new Error(
-                            `stage_name should have been set already for ${event.project_card.column_name}`
-                        )
-                    }
-
-                    toStage = event.project_card.stage_name
-                    toLevel = stageLevel[toStage]
-                    currentStage = toStage
-                }
-
-                if (event.project_card && event.project_card.previous_column_name) {
-                    if (!event.project_card.previous_stage_name) {
-                        throw new Error(
-                            `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
-                        )
-                    }
-
-                    fromStage = event.project_card.previous_stage_name
-                    fromLevel = stageLevel[fromStage]
-                }
-
-                // last occurence of moving to these columns from a lesser or no column
-                // example. if moved to accepted from proposed (or less),
-                //      then in-progress (greater) and then back to accepted, first wins
-                if (
-                    toStage === 'Proposed' ||
-                    toStage === 'Accepted' ||
-                    toStage === 'In-Progress'
-                ) {
-                    if (toLevel > fromLevel) {
-                        issue[this.stageAtNames[toLevel]] = eventDateTime
-                    }
-                    //moving back, clear the stage at dates up to fromLevel
-                    else if (toLevel < fromLevel) {
-                        for (let i = toLevel + 1; i <= fromLevel; i++) {
-                            delete issue[this.stageAtNames[i]]
-                        }
-                    }
-                }
-
-                if (toStage === 'Done') {
-                    doneTime = eventDateTime
-                }
-            }
-
-            // done_at and blocked_at is only set if it's currently at that stage
-            if (currentStage === 'Done') {
-                issue.project_done_at = doneTime
-                console.log(`project_done_at: ${issue.project_done_at}`)
-            }
-
-            if (addedTime) {
-                issue.project_added_at = addedTime
-                console.log(`project_added_at: ${issue.project_added_at}`)
-            }
-
-            issue.project_stage = currentStage
-            console.log(`project_stage: ${issue.project_stage}`)
-        }
-    }
+  }
 }

--- a/project-reports-lib.ts
+++ b/project-reports-lib.ts
@@ -1,5 +1,6 @@
 import clone from 'clone'
 import moment from 'moment'
+import * as os from 'os'
 import * as url from 'url'
 
 // TODO: separate npm module.  for now it's a file till we flush out
@@ -7,32 +8,32 @@ import * as url from 'url'
 export * from './project-reports-schemes'
 
 export interface RepoProps {
-  owner: string
-  repo: string
+    owner: string
+    repo: string
 }
 
 export function repoPropsFromUrl(htmlUrl: string): RepoProps {
-  const rUrl = new url.URL(htmlUrl)
-  const parts = rUrl.pathname.split('/').filter(e => e)
+    const rUrl = new url.URL(htmlUrl)
+    const parts = rUrl.pathname.split('/').filter(e => e)
 
-  return <RepoProps>{
-    owner: parts[0],
-    repo: parts[1]
-  }
+    return <RepoProps>{
+        owner: parts[0],
+        repo: parts[1]
+    }
 }
 //
 // filter cards by label
 //
 export function filterByLabel(
-  issues: ProjectIssue[],
-  name: string
+    issues: ProjectIssue[],
+    name: string
 ): ProjectIssue[] {
-  return issues.filter(
-    card =>
-      card.labels.findIndex(
-        label => label.name.trim().toLowerCase() === name.toLowerCase()
-      ) >= 0
-  )
+    return issues.filter(
+        card =>
+            card.labels.findIndex(
+                label => label.name.trim().toLowerCase() === name.toLowerCase()
+            ) >= 0
+    )
 }
 
 //
@@ -41,432 +42,484 @@ export function filterByLabel(
 // returns NaN if no labels match
 //
 export function getCountFromLabel(card: ProjectIssue, re: RegExp): number {
-  let num = NaN
+    let num = NaN
 
-  for (const label of card.labels) {
-    const matches = label.name.match(re)
-    if (matches && matches.length > 0) {
-      num = parseInt(matches[1])
-      if (num) {
-        break
-      }
+    for (const label of card.labels) {
+        const matches = label.name.match(re)
+        if (matches && matches.length > 0) {
+            num = parseInt(matches[1])
+            if (num) {
+                break
+            }
+        }
     }
-  }
-  return num
+    return num
 }
 
 export function getStringFromLabel(card: ProjectIssue, re: RegExp): string {
-  let str = ''
+    let str = ''
 
-  for (const label of card.labels) {
-    const matches = label.name.trim().match(re)
-    if (matches && matches.length > 0) {
-      str = matches[0]
-      if (str) {
-        break
-      }
+    for (const label of card.labels) {
+        const matches = label.name.trim().match(re)
+        if (matches && matches.length > 0) {
+            str = matches[0]
+            if (str) {
+                break
+            }
+        }
     }
-  }
 
-  if (str) {
-    str = str.trim()
-  }
+    if (str) {
+        str = str.trim()
+    }
 
-  return str
+    return str
+}
+
+export function getLastCommentField(
+    issue: ProjectIssue,
+    field: string
+): string {
+    let val = ''
+
+    if (!issue.comments) {
+        return ''
+    }
+
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i]
+        if (!comment) {
+            break
+        }
+
+        const lines = comment.body.split(os.EOL)
+        for (const line of lines) {
+            const parts = line.trim().split(':')
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim()
+                break
+            }
+        }
+
+        if (val) {
+            break
+        }
+    }
+
+    return val
+}
+
+// returns a valid date field value from a comment field
+export function getLastCommentDateField(
+    issue: ProjectIssue,
+    field: string
+): Date {
+    let d: Date = null
+    const val = getLastCommentField(issue, field)
+
+    try {
+        if (val) {
+            d = new Date(val)
+        }
+    } catch (err) {
+        // if not a valid date, will return null date
+    }
+
+    return d
 }
 
 export function sumCardProperty(cards: ProjectIssue[], prop: string): number {
-  return cards.reduce((a, b) => a + (b[prop] || 0), 0)
+    return cards.reduce((a, b) => a + (b[prop] || 0), 0)
 }
 
 export function fuzzyMatch(content: string, match: string): boolean {
-  let matchWords = match.match(/[a-zA-Z0-9]+/g)
-  matchWords = matchWords.map(item => item.toLowerCase())
+    let matchWords = match.match(/[a-zA-Z0-9]+/g)
+    matchWords = matchWords.map(item => item.toLowerCase())
 
-  let contentWords = content.match(/[a-zA-Z0-9]+/g)
-  contentWords = contentWords.map(item => item.toLowerCase())
+    let contentWords = content.match(/[a-zA-Z0-9]+/g)
+    contentWords = contentWords.map(item => item.toLowerCase())
 
-  let isMatch = true
-  for (const matchWord of matchWords) {
-    if (contentWords.indexOf(matchWord) === -1) {
-      isMatch = false
-      break
+    let isMatch = true
+    for (const matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false
+            break
+        }
     }
-  }
-  return isMatch
+    return isMatch
 }
 
 // Project issues keyed by the stage they are in
 export interface ProjectIssues {
-  stages: {[key: string]: ProjectIssue[]}
+    stages: { [key: string]: ProjectIssue[] }
 }
 
 export interface ProjectColumn {
-  cards_url: string
-  id: number
-  name: string
+    cards_url: string
+    id: number
+    name: string
 }
 
 // stages more discoverable
 export const ProjectStages = {
-  Proposed: 'Proposed',
-  Accepted: 'Accepted',
-  InProgress: 'In-Progress',
-  Done: 'Done',
-  Missing: 'Missing'
+    Proposed: 'Proposed',
+    Accepted: 'Accepted',
+    InProgress: 'In-Progress',
+    Done: 'Done',
+    Missing: 'Missing'
 }
 
-export type ProjectStageIssues = {[key: string]: ProjectIssue[]}
+export type ProjectStageIssues = { [key: string]: ProjectIssue[] }
 
 export function getProjectStageIssues(issues: ProjectIssue[]) {
-  const projIssues = <ProjectStageIssues>{}
-  for (const projIssue of issues) {
-    const stage = projIssue['project_stage']
-    if (!stage) {
-      // the engine will handle and add to an issues list
-      continue
+    const projIssues = <ProjectStageIssues>{}
+    for (const projIssue of issues) {
+        const stage = projIssue['project_stage']
+        if (!stage) {
+            // the engine will handle and add to an issues list
+            continue
+        }
+
+        if (!projIssues[stage]) {
+            projIssues[stage] = []
+        }
+
+        projIssues[stage].push(projIssue)
     }
 
-    if (!projIssues[stage]) {
-      projIssues[stage] = []
-    }
-
-    projIssues[stage].push(projIssue)
-  }
-
-  return projIssues
+    return projIssues
 }
 
 export interface IssueLabel {
-  name: string
+    name: string
 }
 
 export interface IssueCardEventProject {
-  project_id: number
-  column_name: string
-  previous_column_name: string
-  stage_name: string
-  previous_stage_name: string
+    project_id: number
+    column_name: string
+    previous_column_name: string
+    stage_name: string
+    previous_stage_name: string
 }
 
 export interface IssueEvent {
-  created_at: Date
-  event: string
-  assignee: IssueUser
-  label: IssueLabel
-  project_card: IssueCardEventProject
-  //data: any
+    created_at: Date
+    event: string
+    assignee: IssueUser
+    label: IssueLabel
+    project_card: IssueCardEventProject
+    //data: any
 }
 
 export interface IssueUser {
-  login: string
-  id: number
-  avatar_url: string
-  url: string
-  html_url: string
+    login: string
+    id: number
+    avatar_url: string
+    url: string
+    html_url: string
 }
 
 export interface IssueMilestone {
-  title: string
-  description: string
-  due_on: Date
+    title: string
+    description: string
+    due_on: Date
 }
 
 export interface IssueComment {
-  body: string
-  user: IssueUser
-  created_at: Date
-  updated_at: Date
+    body: string
+    user: IssueUser
+    created_at: Date
+    updated_at: Date
 }
 
 export interface ProjectIssue {
-  title: string
-  number: number
-  html_url: string
-  state: string
-  labels: IssueLabel[]
-  assignee: IssueUser
-  assignees: IssueUser[]
-  user: IssueUser
-  milestone: IssueMilestone
-  closed_at: Date
-  created_at: Date
-  updated_at: Date
+    title: string
+    number: number
+    html_url: string
+    state: string
+    labels: IssueLabel[]
+    assignee: IssueUser
+    assignees: IssueUser[]
+    user: IssueUser
+    milestone: IssueMilestone
+    closed_at: Date
+    created_at: Date
+    updated_at: Date
 
-  comments: IssueComment[]
-  events: IssueEvent[]
+    comments: IssueComment[]
+    events: IssueEvent[]
 
-  //
-  // project stage fields we decorate on issues
-  //
+    //
+    // project stage fields we decorate on issues
+    //
 
-  // first added to the board on any column (no "from" column)
-  project_added_at: Date
+    // first added to the board on any column (no "from" column)
+    project_added_at: Date
 
-  // last occurence of moving to these columns from a lesser or no column
-  // example. if moved to accepted from proposed (or less),
-  //      then in-progress (greater) and then back to accepted, first wins
-  project_proposed_at: Date
-  project_accepted_at: Date
-  project_in_progress_at: Date
+    // last occurence of moving to these columns from a lesser or no column
+    // example. if moved to accepted from proposed (or less),
+    //      then in-progress (greater) and then back to accepted, first wins
+    project_proposed_at: Date
+    project_accepted_at: Date
+    project_in_progress_at: Date
 
-  // cleared if not currently blocked
-  project_blocked_at: Date
+    // cleared if not currently blocked
+    project_blocked_at: Date
 
-  // cleared if it moves out of done.  e.g. current state has to be done for this to be set
-  project_done_at: Date
+    // cleared if it moves out of done.  e.g. current state has to be done for this to be set
+    project_done_at: Date
 
-  // current stage of this card on the board
-  project_stage: string
+    // current stage of this card on the board
+    project_stage: string
 }
 
 const stageLevel = {
-  None: 0,
-  Proposed: 1,
-  Accepted: 2,
-  'In-Progress': 3,
-  Done: 4,
-  Unmapped: 5
+    None: 0,
+    Proposed: 1,
+    Accepted: 2,
+    'In-Progress': 3,
+    Done: 4,
+    Unmapped: 5
 }
 
 export class IssueList {
-  seen
-  identifier
-  items: ProjectIssue[]
-  processed: ProjectIssue[]
+    seen
+    identifier
+    items: ProjectIssue[]
+    processed: ProjectIssue[]
 
-  // keep in order indexed by level above
-  // TODO: unify both to avoid out of sync problems
-  stageAtNames = [
-    'none',
-    'project_proposed_at',
-    'project_accepted_at',
-    'project_in_progress_at',
-    'project_done_at'
-  ]
+    // keep in order indexed by level above
+    // TODO: unify both to avoid out of sync problems
+    stageAtNames = [
+        'none',
+        'project_proposed_at',
+        'project_accepted_at',
+        'project_in_progress_at',
+        'project_done_at'
+    ]
 
-  constructor(identifier: (item) => any) {
-    this.seen = new Map()
-    this.identifier = identifier
-    this.items = []
-  }
-
-  // returns whether any were added
-  public add(data: any | any[]): boolean {
-    this.processed = null
-    let added = false
-    if (Array.isArray(data)) {
-      for (const item of data) {
-        const res = this.add_item(item)
-        if (!added) {
-          added = res
-        }
-      }
-    } else {
-      return this.add_item(data)
+    constructor(identifier: (item) => any) {
+        this.seen = new Map()
+        this.identifier = identifier
+        this.items = []
     }
 
-    return added
-  }
-
-  private add_item(item: any): boolean {
-    const id = this.identifier(item)
-
-    if (!this.seen.has(id)) {
-      this.items.push(item)
-      this.seen.set(id, item)
-      return true
-    }
-
-    return false
-  }
-
-  public getItem(identifier: any): ProjectIssue {
-    return this.seen.get(identifier)
-  }
-
-  public getItems(): ProjectIssue[] {
-    if (this.processed) {
-      return this.processed
-    }
-
-    // call process
-    for (const item of this.items) {
-      this.processStages(item)
-    }
-
-    this.processed = this.items
-    return this.processed
-  }
-
-  //
-  // Gets an issue from a number of days, hours ago.
-  // Clones the issue and Replays events (labels, column moves, milestones)
-  // and reprocesses the stages.
-  // If the issue doesn't exist in the list, returns null
-  //
-  public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
-    console.log(`getting asof ${datetime} : ${identifier}`)
-    let issue = this.getItem(identifier)
-
-    if (!issue) {
-      return issue
-    }
-
-    issue = clone(issue)
-    const momentAgo = moment(datetime)
-
-    // clear everything we're going to re-apply
-    issue.labels = []
-    delete issue.project_added_at
-    delete issue.project_proposed_at
-    delete issue.project_in_progress_at
-    delete issue.project_accepted_at
-    delete issue.project_done_at
-    delete issue.project_stage
-    delete issue.closed_at
-
-    // stages and labels
-    const filteredEvents: IssueEvent[] = []
-    const labelMap: {[name: string]: IssueLabel} = {}
-
-    if (issue.events) {
-      for (const event of issue.events) {
-        if (moment(event.created_at).isAfter(momentAgo)) {
-          continue
-        }
-
-        filteredEvents.push(event)
-
-        if (event.event === 'labeled') {
-          labelMap[event.label.name] = event.label
-        } else if (event.event === 'unlabeled') {
-          delete labelMap[event.label.name]
-        }
-
-        if (event.event === 'closed') {
-          issue.closed_at = event.created_at
-        }
-
-        if (event.event === 'reopened') {
-          delete issue.closed_at
-        }
-      }
-    }
-    issue.events = filteredEvents
-
-    for (const labelName in labelMap) {
-      issue.labels.push(labelMap[labelName])
-    }
-
-    this.processStages(issue)
-
-    // comments
-    const filteredComments: IssueComment[] = []
-    for (const comment of issue.comments) {
-      if (moment(comment.created_at).isAfter(momentAgo)) {
-        continue
-      }
-
-      filteredComments.push(comment)
-    }
-    issue.comments = filteredComments
-
-    return issue
-  }
-
-  //
-  // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
-  // Call initially and then call again if events are filtered (get issue asof)
-  //
-  private processStages(issue: ProjectIssue): void {
-    console.log(`Processing stages for ${issue.html_url}`)
-    // card events should be in order chronologically
-    let currentStage: string
-    let doneTime: Date
-    let addedTime: Date
-
-    const tempLabels = {}
-
-    if (issue.events) {
-      for (const event of issue.events) {
-        let eventDateTime: Date
-        if (event.created_at) {
-          eventDateTime = event.created_at
-        }
-
-        //
-        // Process Project Stages
-        //
-        let toStage: string
-        let toLevel: number
-        let fromStage: string
-        let fromLevel = 0
-
-        if (event.project_card && event.project_card.column_name) {
-          if (!addedTime) {
-            addedTime = eventDateTime
-          }
-
-          if (!event.project_card.stage_name) {
-            throw new Error(
-              `stage_name should have been set already for ${event.project_card.column_name}`
-            )
-          }
-
-          toStage = event.project_card.stage_name
-          toLevel = stageLevel[toStage]
-          currentStage = toStage
-        }
-
-        if (event.project_card && event.project_card.previous_column_name) {
-          if (!event.project_card.previous_stage_name) {
-            throw new Error(
-              `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
-            )
-          }
-
-          fromStage = event.project_card.previous_stage_name
-          fromLevel = stageLevel[fromStage]
-        }
-
-        // last occurence of moving to these columns from a lesser or no column
-        // example. if moved to accepted from proposed (or less),
-        //      then in-progress (greater) and then back to accepted, first wins
-        if (
-          toStage === 'Proposed' ||
-          toStage === 'Accepted' ||
-          toStage === 'In-Progress'
-        ) {
-          if (toLevel > fromLevel) {
-            issue[this.stageAtNames[toLevel]] = eventDateTime
-          }
-          //moving back, clear the stage at dates up to fromLevel
-          else if (toLevel < fromLevel) {
-            for (let i = toLevel + 1; i <= fromLevel; i++) {
-              delete issue[this.stageAtNames[i]]
+    // returns whether any were added
+    public add(data: any | any[]): boolean {
+        this.processed = null
+        let added = false
+        if (Array.isArray(data)) {
+            for (const item of data) {
+                const res = this.add_item(item)
+                if (!added) {
+                    added = res
+                }
             }
-          }
+        } else {
+            return this.add_item(data)
         }
 
-        if (toStage === 'Done') {
-          doneTime = eventDateTime
-        }
-      }
-
-      // done_at and blocked_at is only set if it's currently at that stage
-      if (currentStage === 'Done') {
-        issue.project_done_at = doneTime
-        console.log(`project_done_at: ${issue.project_done_at}`)
-      }
-
-      if (addedTime) {
-        issue.project_added_at = addedTime
-        console.log(`project_added_at: ${issue.project_added_at}`)
-      }
-
-      issue.project_stage = currentStage
-      console.log(`project_stage: ${issue.project_stage}`)
+        return added
     }
-  }
+
+    private add_item(item: any): boolean {
+        const id = this.identifier(item)
+
+        if (!this.seen.has(id)) {
+            this.items.push(item)
+            this.seen.set(id, item)
+            return true
+        }
+
+        return false
+    }
+
+    public getItem(identifier: any): ProjectIssue {
+        return this.seen.get(identifier)
+    }
+
+    public getItems(): ProjectIssue[] {
+        if (this.processed) {
+            return this.processed
+        }
+
+        // call process
+        for (const item of this.items) {
+            this.processStages(item)
+        }
+
+        this.processed = this.items
+        return this.processed
+    }
+
+    //
+    // Gets an issue from a number of days, hours ago.
+    // Clones the issue and Replays events (labels, column moves, milestones)
+    // and reprocesses the stages.
+    // If the issue doesn't exist in the list, returns null
+    //
+    public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
+        console.log(`getting asof ${datetime} : ${identifier}`)
+        let issue = this.getItem(identifier)
+
+        if (!issue) {
+            return issue
+        }
+
+        issue = clone(issue)
+        const momentAgo = moment(datetime)
+
+        // clear everything we're going to re-apply
+        issue.labels = []
+        delete issue.project_added_at
+        delete issue.project_proposed_at
+        delete issue.project_in_progress_at
+        delete issue.project_accepted_at
+        delete issue.project_done_at
+        delete issue.project_stage
+        delete issue.closed_at
+
+        // stages and labels
+        const filteredEvents: IssueEvent[] = []
+        const labelMap: { [name: string]: IssueLabel } = {}
+
+        if (issue.events) {
+            for (const event of issue.events) {
+                if (moment(event.created_at).isAfter(momentAgo)) {
+                    continue
+                }
+
+                filteredEvents.push(event)
+
+                if (event.event === 'labeled') {
+                    labelMap[event.label.name] = event.label
+                } else if (event.event === 'unlabeled') {
+                    delete labelMap[event.label.name]
+                }
+
+                if (event.event === 'closed') {
+                    issue.closed_at = event.created_at
+                }
+
+                if (event.event === 'reopened') {
+                    delete issue.closed_at
+                }
+            }
+        }
+        issue.events = filteredEvents
+
+        for (const labelName in labelMap) {
+            issue.labels.push(labelMap[labelName])
+        }
+
+        this.processStages(issue)
+
+        // comments
+        const filteredComments: IssueComment[] = []
+        for (const comment of issue.comments) {
+            if (moment(comment.created_at).isAfter(momentAgo)) {
+                continue
+            }
+
+            filteredComments.push(comment)
+        }
+        issue.comments = filteredComments
+
+        return issue
+    }
+
+    //
+    // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
+    // Call initially and then call again if events are filtered (get issue asof)
+    //
+    private processStages(issue: ProjectIssue): void {
+        console.log(`Processing stages for ${issue.html_url}`)
+        // card events should be in order chronologically
+        let currentStage: string
+        let doneTime: Date
+        let addedTime: Date
+
+        const tempLabels = {}
+
+        if (issue.events) {
+            for (const event of issue.events) {
+                let eventDateTime: Date
+                if (event.created_at) {
+                    eventDateTime = event.created_at
+                }
+
+                //
+                // Process Project Stages
+                //
+                let toStage: string
+                let toLevel: number
+                let fromStage: string
+                let fromLevel = 0
+
+                if (event.project_card && event.project_card.column_name) {
+                    if (!addedTime) {
+                        addedTime = eventDateTime
+                    }
+
+                    if (!event.project_card.stage_name) {
+                        throw new Error(
+                            `stage_name should have been set already for ${event.project_card.column_name}`
+                        )
+                    }
+
+                    toStage = event.project_card.stage_name
+                    toLevel = stageLevel[toStage]
+                    currentStage = toStage
+                }
+
+                if (event.project_card && event.project_card.previous_column_name) {
+                    if (!event.project_card.previous_stage_name) {
+                        throw new Error(
+                            `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
+                        )
+                    }
+
+                    fromStage = event.project_card.previous_stage_name
+                    fromLevel = stageLevel[fromStage]
+                }
+
+                // last occurence of moving to these columns from a lesser or no column
+                // example. if moved to accepted from proposed (or less),
+                //      then in-progress (greater) and then back to accepted, first wins
+                if (
+                    toStage === 'Proposed' ||
+                    toStage === 'Accepted' ||
+                    toStage === 'In-Progress'
+                ) {
+                    if (toLevel > fromLevel) {
+                        issue[this.stageAtNames[toLevel]] = eventDateTime
+                    }
+                    //moving back, clear the stage at dates up to fromLevel
+                    else if (toLevel < fromLevel) {
+                        for (let i = toLevel + 1; i <= fromLevel; i++) {
+                            delete issue[this.stageAtNames[i]]
+                        }
+                    }
+                }
+
+                if (toStage === 'Done') {
+                    doneTime = eventDateTime
+                }
+            }
+
+            // done_at and blocked_at is only set if it's currently at that stage
+            if (currentStage === 'Done') {
+                issue.project_done_at = doneTime
+                console.log(`project_done_at: ${issue.project_done_at}`)
+            }
+
+            if (addedTime) {
+                issue.project_added_at = addedTime
+                console.log(`project_added_at: ${issue.project_added_at}`)
+            }
+
+            issue.project_stage = currentStage
+            console.log(`project_stage: ${issue.project_stage}`)
+        }
+    }
 }

--- a/project-reports-lib.ts
+++ b/project-reports-lib.ts
@@ -8,32 +8,32 @@ import * as url from 'url'
 export * from './project-reports-schemes'
 
 export interface RepoProps {
-  owner: string
-  repo: string
+    owner: string
+    repo: string
 }
 
 export function repoPropsFromUrl(htmlUrl: string): RepoProps {
-  const rUrl = new url.URL(htmlUrl)
-  const parts = rUrl.pathname.split('/').filter(e => e)
+    const rUrl = new url.URL(htmlUrl)
+    const parts = rUrl.pathname.split('/').filter(e => e)
 
-  return <RepoProps>{
-    owner: parts[0],
-    repo: parts[1]
-  }
+    return <RepoProps>{
+        owner: parts[0],
+        repo: parts[1]
+    }
 }
 //
 // filter cards by label
 //
 export function filterByLabel(
-  issues: ProjectIssue[],
-  name: string
+    issues: ProjectIssue[],
+    name: string
 ): ProjectIssue[] {
-  return issues.filter(
-    card =>
-      card.labels.findIndex(
-        label => label.name.trim().toLowerCase() === name.toLowerCase()
-      ) >= 0
-  )
+    return issues.filter(
+        card =>
+            card.labels.findIndex(
+                label => label.name.trim().toLowerCase() === name.toLowerCase()
+            ) >= 0
+    )
 }
 
 //
@@ -42,484 +42,480 @@ export function filterByLabel(
 // returns NaN if no labels match
 //
 export function getCountFromLabel(card: ProjectIssue, re: RegExp): number {
-  let num = NaN
+    let num = NaN
 
-  for (const label of card.labels) {
-    const matches = label.name.match(re)
-    if (matches && matches.length > 0) {
-      num = parseInt(matches[1])
-      if (num) {
-        break
-      }
+    for (const label of card.labels) {
+        const matches = label.name.match(re)
+        if (matches && matches.length > 0) {
+            num = parseInt(matches[1])
+            if (num) {
+                break
+            }
+        }
     }
-  }
-  return num
+    return num
 }
 
 export function getStringFromLabel(card: ProjectIssue, re: RegExp): string {
-  let str = ''
+    let str = ''
 
-  for (const label of card.labels) {
-    const matches = label.name.trim().match(re)
-    if (matches && matches.length > 0) {
-      str = matches[0]
-      if (str) {
-        break
-      }
+    for (const label of card.labels) {
+        const matches = label.name.trim().match(re)
+        if (matches && matches.length > 0) {
+            str = matches[0]
+            if (str) {
+                break
+            }
+        }
     }
-  }
 
-  if (str) {
-    str = str.trim()
-  }
+    if (str) {
+        str = str.trim()
+    }
 
-  return str
+    return str
 }
 
 export function getLastCommentField(
-  issue: ProjectIssue,
-  field: string
+    issue: ProjectIssue,
+    field: string
 ): string {
-  let val = ''
+    let val = ''
 
-  if (!issue.comments) {
-    return ''
-  }
-
-  for (let i = issue.comments.length - 1; i >= 0; i--) {
-    const comment = issue.comments[i]
-    if (!comment) {
-      break
+    if (!issue.comments) {
+        return ''
     }
 
-    const lines = comment.body.split(os.EOL)
-    for (const line of lines) {
-      const parts = line.trim().split(':')
-      if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
-        val = parts[1].trim()
-        break
-      }
+    for (let i = issue.comments.length - 1; i >= 0; i--) {
+        const comment = issue.comments[i]
+        if (!comment) {
+            break
+        }
+
+        const lines = comment.body.split(os.EOL)
+        for (const line of lines) {
+            const parts = line.trim().split(':')
+            if (parts.length === 2 && fuzzyMatch(parts[0], field)) {
+                val = parts[1].trim()
+                break
+            }
+        }
+
+        if (val) {
+            break
+        }
     }
 
-    if (val) {
-      break
-    }
-  }
-
-  return val
+    return val
 }
 
 // returns a valid date field value from a comment field
 export function getLastCommentDateField(
-  issue: ProjectIssue,
-  field: string
+    issue: ProjectIssue,
+    field: string
 ): Date {
-  let d: Date = null
-  const val = getLastCommentField(issue, field)
+    let d: Date = null
+    const val = getLastCommentField(issue, field)
 
-  try {
     if (val) {
-      d = new Date(val)
+        d = new Date(val)
     }
-  } catch (err) {
-    // if not a valid date, will return null date
-  }
 
-  return d
+    return d
 }
 
 export function sumCardProperty(cards: ProjectIssue[], prop: string): number {
-  return cards.reduce((a, b) => a + (b[prop] || 0), 0)
+    return cards.reduce((a, b) => a + (b[prop] || 0), 0)
 }
 
 export function fuzzyMatch(content: string, match: string): boolean {
-  let matchWords = match.match(/[a-zA-Z0-9]+/g)
-  matchWords = matchWords.map(item => item.toLowerCase())
+    let matchWords = match.match(/[a-zA-Z0-9]+/g)
+    matchWords = matchWords.map(item => item.toLowerCase())
 
-  let contentWords = content.match(/[a-zA-Z0-9]+/g)
-  contentWords = contentWords.map(item => item.toLowerCase())
+    let contentWords = content.match(/[a-zA-Z0-9]+/g)
+    contentWords = contentWords.map(item => item.toLowerCase())
 
-  let isMatch = true
-  for (const matchWord of matchWords) {
-    if (contentWords.indexOf(matchWord) === -1) {
-      isMatch = false
-      break
+    let isMatch = true
+    for (const matchWord of matchWords) {
+        if (contentWords.indexOf(matchWord) === -1) {
+            isMatch = false
+            break
+        }
     }
-  }
-  return isMatch
+    return isMatch
 }
 
 // Project issues keyed by the stage they are in
 export interface ProjectIssues {
-  stages: {[key: string]: ProjectIssue[]}
+    stages: { [key: string]: ProjectIssue[] }
 }
 
 export interface ProjectColumn {
-  cards_url: string
-  id: number
-  name: string
+    cards_url: string
+    id: number
+    name: string
 }
 
 // stages more discoverable
 export const ProjectStages = {
-  Proposed: 'Proposed',
-  Accepted: 'Accepted',
-  InProgress: 'In-Progress',
-  Done: 'Done',
-  Missing: 'Missing'
+    Proposed: 'Proposed',
+    Accepted: 'Accepted',
+    InProgress: 'In-Progress',
+    Done: 'Done',
+    Missing: 'Missing'
 }
 
-export type ProjectStageIssues = {[key: string]: ProjectIssue[]}
+export type ProjectStageIssues = { [key: string]: ProjectIssue[] }
 
 export function getProjectStageIssues(issues: ProjectIssue[]) {
-  const projIssues = <ProjectStageIssues>{}
-  for (const projIssue of issues) {
-    const stage = projIssue['project_stage']
-    if (!stage) {
-      // the engine will handle and add to an issues list
-      continue
+    const projIssues = <ProjectStageIssues>{}
+    for (const projIssue of issues) {
+        const stage = projIssue['project_stage']
+        if (!stage) {
+            // the engine will handle and add to an issues list
+            continue
+        }
+
+        if (!projIssues[stage]) {
+            projIssues[stage] = []
+        }
+
+        projIssues[stage].push(projIssue)
     }
 
-    if (!projIssues[stage]) {
-      projIssues[stage] = []
-    }
-
-    projIssues[stage].push(projIssue)
-  }
-
-  return projIssues
+    return projIssues
 }
 
 export interface IssueLabel {
-  name: string
+    name: string
 }
 
 export interface IssueCardEventProject {
-  project_id: number
-  column_name: string
-  previous_column_name: string
-  stage_name: string
-  previous_stage_name: string
+    project_id: number
+    column_name: string
+    previous_column_name: string
+    stage_name: string
+    previous_stage_name: string
 }
 
 export interface IssueEvent {
-  created_at: Date
-  event: string
-  assignee: IssueUser
-  label: IssueLabel
-  project_card: IssueCardEventProject
-  //data: any
+    created_at: Date
+    event: string
+    assignee: IssueUser
+    label: IssueLabel
+    project_card: IssueCardEventProject
+    //data: any
 }
 
 export interface IssueUser {
-  login: string
-  id: number
-  avatar_url: string
-  url: string
-  html_url: string
+    login: string
+    id: number
+    avatar_url: string
+    url: string
+    html_url: string
 }
 
 export interface IssueMilestone {
-  title: string
-  description: string
-  due_on: Date
+    title: string
+    description: string
+    due_on: Date
 }
 
 export interface IssueComment {
-  body: string
-  user: IssueUser
-  created_at: Date
-  updated_at: Date
+    body: string
+    user: IssueUser
+    created_at: Date
+    updated_at: Date
 }
 
 export interface ProjectIssue {
-  title: string
-  number: number
-  html_url: string
-  state: string
-  labels: IssueLabel[]
-  assignee: IssueUser
-  assignees: IssueUser[]
-  user: IssueUser
-  milestone: IssueMilestone
-  closed_at: Date
-  created_at: Date
-  updated_at: Date
+    title: string
+    number: number
+    html_url: string
+    state: string
+    labels: IssueLabel[]
+    assignee: IssueUser
+    assignees: IssueUser[]
+    user: IssueUser
+    milestone: IssueMilestone
+    closed_at: Date
+    created_at: Date
+    updated_at: Date
 
-  comments: IssueComment[]
-  events: IssueEvent[]
+    comments: IssueComment[]
+    events: IssueEvent[]
 
-  //
-  // project stage fields we decorate on issues
-  //
+    //
+    // project stage fields we decorate on issues
+    //
 
-  // first added to the board on any column (no "from" column)
-  project_added_at: Date
+    // first added to the board on any column (no "from" column)
+    project_added_at: Date
 
-  // last occurence of moving to these columns from a lesser or no column
-  // example. if moved to accepted from proposed (or less),
-  //      then in-progress (greater) and then back to accepted, first wins
-  project_proposed_at: Date
-  project_accepted_at: Date
-  project_in_progress_at: Date
+    // last occurence of moving to these columns from a lesser or no column
+    // example. if moved to accepted from proposed (or less),
+    //      then in-progress (greater) and then back to accepted, first wins
+    project_proposed_at: Date
+    project_accepted_at: Date
+    project_in_progress_at: Date
 
-  // cleared if not currently blocked
-  project_blocked_at: Date
+    // cleared if not currently blocked
+    project_blocked_at: Date
 
-  // cleared if it moves out of done.  e.g. current state has to be done for this to be set
-  project_done_at: Date
+    // cleared if it moves out of done.  e.g. current state has to be done for this to be set
+    project_done_at: Date
 
-  // current stage of this card on the board
-  project_stage: string
+    // current stage of this card on the board
+    project_stage: string
 }
 
 const stageLevel = {
-  None: 0,
-  Proposed: 1,
-  Accepted: 2,
-  'In-Progress': 3,
-  Done: 4,
-  Unmapped: 5
+    None: 0,
+    Proposed: 1,
+    Accepted: 2,
+    'In-Progress': 3,
+    Done: 4,
+    Unmapped: 5
 }
 
 export class IssueList {
-  seen
-  identifier
-  items: ProjectIssue[]
-  processed: ProjectIssue[]
+    seen
+    identifier
+    items: ProjectIssue[]
+    processed: ProjectIssue[]
 
-  // keep in order indexed by level above
-  // TODO: unify both to avoid out of sync problems
-  stageAtNames = [
-    'none',
-    'project_proposed_at',
-    'project_accepted_at',
-    'project_in_progress_at',
-    'project_done_at'
-  ]
+    // keep in order indexed by level above
+    // TODO: unify both to avoid out of sync problems
+    stageAtNames = [
+        'none',
+        'project_proposed_at',
+        'project_accepted_at',
+        'project_in_progress_at',
+        'project_done_at'
+    ]
 
-  constructor(identifier: (item) => any) {
-    this.seen = new Map()
-    this.identifier = identifier
-    this.items = []
-  }
-
-  // returns whether any were added
-  public add(data: any | any[]): boolean {
-    this.processed = null
-    let added = false
-    if (Array.isArray(data)) {
-      for (const item of data) {
-        const res = this.add_item(item)
-        if (!added) {
-          added = res
-        }
-      }
-    } else {
-      return this.add_item(data)
+    constructor(identifier: (item) => any) {
+        this.seen = new Map()
+        this.identifier = identifier
+        this.items = []
     }
 
-    return added
-  }
-
-  private add_item(item: any): boolean {
-    const id = this.identifier(item)
-
-    if (!this.seen.has(id)) {
-      this.items.push(item)
-      this.seen.set(id, item)
-      return true
-    }
-
-    return false
-  }
-
-  public getItem(identifier: any): ProjectIssue {
-    return this.seen.get(identifier)
-  }
-
-  public getItems(): ProjectIssue[] {
-    if (this.processed) {
-      return this.processed
-    }
-
-    // call process
-    for (const item of this.items) {
-      this.processStages(item)
-    }
-
-    this.processed = this.items
-    return this.processed
-  }
-
-  //
-  // Gets an issue from a number of days, hours ago.
-  // Clones the issue and Replays events (labels, column moves, milestones)
-  // and reprocesses the stages.
-  // If the issue doesn't exist in the list, returns null
-  //
-  public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
-    console.log(`getting asof ${datetime} : ${identifier}`)
-    let issue = this.getItem(identifier)
-
-    if (!issue) {
-      return issue
-    }
-
-    issue = clone(issue)
-    const momentAgo = moment(datetime)
-
-    // clear everything we're going to re-apply
-    issue.labels = []
-    delete issue.project_added_at
-    delete issue.project_proposed_at
-    delete issue.project_in_progress_at
-    delete issue.project_accepted_at
-    delete issue.project_done_at
-    delete issue.project_stage
-    delete issue.closed_at
-
-    // stages and labels
-    const filteredEvents: IssueEvent[] = []
-    const labelMap: {[name: string]: IssueLabel} = {}
-
-    if (issue.events) {
-      for (const event of issue.events) {
-        if (moment(event.created_at).isAfter(momentAgo)) {
-          continue
-        }
-
-        filteredEvents.push(event)
-
-        if (event.event === 'labeled') {
-          labelMap[event.label.name] = event.label
-        } else if (event.event === 'unlabeled') {
-          delete labelMap[event.label.name]
-        }
-
-        if (event.event === 'closed') {
-          issue.closed_at = event.created_at
-        }
-
-        if (event.event === 'reopened') {
-          delete issue.closed_at
-        }
-      }
-    }
-    issue.events = filteredEvents
-
-    for (const labelName in labelMap) {
-      issue.labels.push(labelMap[labelName])
-    }
-
-    this.processStages(issue)
-
-    // comments
-    const filteredComments: IssueComment[] = []
-    for (const comment of issue.comments) {
-      if (moment(comment.created_at).isAfter(momentAgo)) {
-        continue
-      }
-
-      filteredComments.push(comment)
-    }
-    issue.comments = filteredComments
-
-    return issue
-  }
-
-  //
-  // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
-  // Call initially and then call again if events are filtered (get issue asof)
-  //
-  private processStages(issue: ProjectIssue): void {
-    console.log(`Processing stages for ${issue.html_url}`)
-    // card events should be in order chronologically
-    let currentStage: string
-    let doneTime: Date
-    let addedTime: Date
-
-    const tempLabels = {}
-
-    if (issue.events) {
-      for (const event of issue.events) {
-        let eventDateTime: Date
-        if (event.created_at) {
-          eventDateTime = event.created_at
-        }
-
-        //
-        // Process Project Stages
-        //
-        let toStage: string
-        let toLevel: number
-        let fromStage: string
-        let fromLevel = 0
-
-        if (event.project_card && event.project_card.column_name) {
-          if (!addedTime) {
-            addedTime = eventDateTime
-          }
-
-          if (!event.project_card.stage_name) {
-            throw new Error(
-              `stage_name should have been set already for ${event.project_card.column_name}`
-            )
-          }
-
-          toStage = event.project_card.stage_name
-          toLevel = stageLevel[toStage]
-          currentStage = toStage
-        }
-
-        if (event.project_card && event.project_card.previous_column_name) {
-          if (!event.project_card.previous_stage_name) {
-            throw new Error(
-              `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
-            )
-          }
-
-          fromStage = event.project_card.previous_stage_name
-          fromLevel = stageLevel[fromStage]
-        }
-
-        // last occurence of moving to these columns from a lesser or no column
-        // example. if moved to accepted from proposed (or less),
-        //      then in-progress (greater) and then back to accepted, first wins
-        if (
-          toStage === 'Proposed' ||
-          toStage === 'Accepted' ||
-          toStage === 'In-Progress'
-        ) {
-          if (toLevel > fromLevel) {
-            issue[this.stageAtNames[toLevel]] = eventDateTime
-          }
-          //moving back, clear the stage at dates up to fromLevel
-          else if (toLevel < fromLevel) {
-            for (let i = toLevel + 1; i <= fromLevel; i++) {
-              delete issue[this.stageAtNames[i]]
+    // returns whether any were added
+    public add(data: any | any[]): boolean {
+        this.processed = null
+        let added = false
+        if (Array.isArray(data)) {
+            for (const item of data) {
+                const res = this.add_item(item)
+                if (!added) {
+                    added = res
+                }
             }
-          }
+        } else {
+            return this.add_item(data)
         }
 
-        if (toStage === 'Done') {
-          doneTime = eventDateTime
-        }
-      }
-
-      // done_at and blocked_at is only set if it's currently at that stage
-      if (currentStage === 'Done') {
-        issue.project_done_at = doneTime
-        console.log(`project_done_at: ${issue.project_done_at}`)
-      }
-
-      if (addedTime) {
-        issue.project_added_at = addedTime
-        console.log(`project_added_at: ${issue.project_added_at}`)
-      }
-
-      issue.project_stage = currentStage
-      console.log(`project_stage: ${issue.project_stage}`)
+        return added
     }
-  }
+
+    private add_item(item: any): boolean {
+        const id = this.identifier(item)
+
+        if (!this.seen.has(id)) {
+            this.items.push(item)
+            this.seen.set(id, item)
+            return true
+        }
+
+        return false
+    }
+
+    public getItem(identifier: any): ProjectIssue {
+        return this.seen.get(identifier)
+    }
+
+    public getItems(): ProjectIssue[] {
+        if (this.processed) {
+            return this.processed
+        }
+
+        // call process
+        for (const item of this.items) {
+            this.processStages(item)
+        }
+
+        this.processed = this.items
+        return this.processed
+    }
+
+    //
+    // Gets an issue from a number of days, hours ago.
+    // Clones the issue and Replays events (labels, column moves, milestones)
+    // and reprocesses the stages.
+    // If the issue doesn't exist in the list, returns null
+    //
+    public getItemAsof(identifier: any, datetime: string | Date): ProjectIssue {
+        console.log(`getting asof ${datetime} : ${identifier}`)
+        let issue = this.getItem(identifier)
+
+        if (!issue) {
+            return issue
+        }
+
+        issue = clone(issue)
+        const momentAgo = moment(datetime)
+
+        // clear everything we're going to re-apply
+        issue.labels = []
+        delete issue.project_added_at
+        delete issue.project_proposed_at
+        delete issue.project_in_progress_at
+        delete issue.project_accepted_at
+        delete issue.project_done_at
+        delete issue.project_stage
+        delete issue.closed_at
+
+        // stages and labels
+        const filteredEvents: IssueEvent[] = []
+        const labelMap: { [name: string]: IssueLabel } = {}
+
+        if (issue.events) {
+            for (const event of issue.events) {
+                if (moment(event.created_at).isAfter(momentAgo)) {
+                    continue
+                }
+
+                filteredEvents.push(event)
+
+                if (event.event === 'labeled') {
+                    labelMap[event.label.name] = event.label
+                } else if (event.event === 'unlabeled') {
+                    delete labelMap[event.label.name]
+                }
+
+                if (event.event === 'closed') {
+                    issue.closed_at = event.created_at
+                }
+
+                if (event.event === 'reopened') {
+                    delete issue.closed_at
+                }
+            }
+        }
+        issue.events = filteredEvents
+
+        for (const labelName in labelMap) {
+            issue.labels.push(labelMap[labelName])
+        }
+
+        this.processStages(issue)
+
+        // comments
+        const filteredComments: IssueComment[] = []
+        for (const comment of issue.comments) {
+            if (moment(comment.created_at).isAfter(momentAgo)) {
+                continue
+            }
+
+            filteredComments.push(comment)
+        }
+        issue.comments = filteredComments
+
+        return issue
+    }
+
+    //
+    // Process the events to set project specific fields like project_done_at, project_in_progress_at, etc
+    // Call initially and then call again if events are filtered (get issue asof)
+    //
+    private processStages(issue: ProjectIssue): void {
+        console.log(`Processing stages for ${issue.html_url}`)
+        // card events should be in order chronologically
+        let currentStage: string
+        let doneTime: Date
+        let addedTime: Date
+
+        const tempLabels = {}
+
+        if (issue.events) {
+            for (const event of issue.events) {
+                let eventDateTime: Date
+                if (event.created_at) {
+                    eventDateTime = event.created_at
+                }
+
+                //
+                // Process Project Stages
+                //
+                let toStage: string
+                let toLevel: number
+                let fromStage: string
+                let fromLevel = 0
+
+                if (event.project_card && event.project_card.column_name) {
+                    if (!addedTime) {
+                        addedTime = eventDateTime
+                    }
+
+                    if (!event.project_card.stage_name) {
+                        throw new Error(
+                            `stage_name should have been set already for ${event.project_card.column_name}`
+                        )
+                    }
+
+                    toStage = event.project_card.stage_name
+                    toLevel = stageLevel[toStage]
+                    currentStage = toStage
+                }
+
+                if (event.project_card && event.project_card.previous_column_name) {
+                    if (!event.project_card.previous_stage_name) {
+                        throw new Error(
+                            `previous_stage_name should have been set already for ${event.project_card.previous_column_name}`
+                        )
+                    }
+
+                    fromStage = event.project_card.previous_stage_name
+                    fromLevel = stageLevel[fromStage]
+                }
+
+                // last occurence of moving to these columns from a lesser or no column
+                // example. if moved to accepted from proposed (or less),
+                //      then in-progress (greater) and then back to accepted, first wins
+                if (
+                    toStage === 'Proposed' ||
+                    toStage === 'Accepted' ||
+                    toStage === 'In-Progress'
+                ) {
+                    if (toLevel > fromLevel) {
+                        issue[this.stageAtNames[toLevel]] = eventDateTime
+                    }
+                    //moving back, clear the stage at dates up to fromLevel
+                    else if (toLevel < fromLevel) {
+                        for (let i = toLevel + 1; i <= fromLevel; i++) {
+                            delete issue[this.stageAtNames[i]]
+                        }
+                    }
+                }
+
+                if (toStage === 'Done') {
+                    doneTime = eventDateTime
+                }
+            }
+
+            // done_at and blocked_at is only set if it's currently at that stage
+            if (currentStage === 'Done') {
+                issue.project_done_at = doneTime
+                console.log(`project_done_at: ${issue.project_done_at}`)
+            }
+
+            if (addedTime) {
+                issue.project_added_at = addedTime
+                console.log(`project_added_at: ${issue.project_added_at}`)
+            }
+
+            issue.project_stage = currentStage
+            console.log(`project_stage: ${issue.project_stage}`)
+        }
+    }
 }


### PR DESCRIPTION
report lib offers a method to get a fields value from the last comment in an issue.

for example, to update the target date for an issue, a comment would be added like:

```
target date: 8/29/2020
```

This method will extract the last target date.  This allows us to add target date to the execution report and flag if past target date etc.  Since it's a comment, the current support for asof will allow the in progress report to compare and see if a feature has been delayed.
